### PR TITLE
fix: normalize windows file paths to prevent legacy octal literal errors

### DIFF
--- a/src/generate.ts
+++ b/src/generate.ts
@@ -94,13 +94,13 @@ export function generateEntryPoint(options: GenerateOptions): void {
   const staticDir = join(distDir, "static");
   const staticFiles = walkDir(staticDir).map((f) => ({
     ...f,
-    urlPath: `/_next/static/${f.relativePath}`,
+    urlPath: `/_next/static/${f.relativePath.replace(/\\/g, "/")}`,
   }));
 
   const publicDir = join(projectDir, "public");
   const publicFiles = walkDir(publicDir).map((f) => ({
     ...f,
-    urlPath: `/${f.relativePath}`,
+    urlPath: `/${f.relativePath.replace(/\\/g, "/")}`,
   }));
 
   // Check build context for assetPrefix — if set, static assets are served


### PR DESCRIPTION
### What does this PR do?
Fixes a crash that occurs on Windows machines during the build step (`Invalid legacy octal literal`). 

### Why is this necessary?
On Windows, `f.relativePath` returns paths using backslashes (e.g., `chunks\284856.js`). When injected directly into the `urlPath` template literal without escaping or replacing them, JavaScript interprets combinations like `\284` or `\00d` in the generated `assets.generated.js` file as legacy octal escape sequences, causing the compiler to instantly crash.

### How was this fixed?
Appended `.replace(/\\/g, "/")` to the `relativePath` variable when generating `urlPath` for both `staticFiles` and `publicFiles` inside `src/generate.ts`. This ensures forward slashes are used universally for web paths and acts as a safe no-op on macOS/Linux.