### PR TITLE
Fix Windows EPERM on bun hoisted-store symlinks (#15)

### DIFF
--- a/src/generate.test.ts
+++ b/src/generate.test.ts
@@ -1,5 +1,12 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { mkdirSync, writeFileSync, existsSync, readFileSync, rmSync } from "node:fs";
+import {
+  mkdirSync,
+  writeFileSync,
+  existsSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+} from "node:fs";
 import { join } from "node:path";
 import { generateEntryPoint } from "./generate.js";
 
@@ -231,6 +238,54 @@ describe("generateEntryPoint", () => {
           "dist/server/lib/router-utils/setup-dev-bundler.js"
         )
       )
+    ).toBe(true);
+  });
+
+  test("tolerates unstattable symlinks in node_modules (Windows EPERM, bun#4533)", () => {
+    const root = join(tmpBase, "broken-symlink");
+    const distDir = join(root, ".next");
+    const standaloneDir = join(distDir, "standalone");
+    const projectDir = root;
+
+    scaffold(root, {
+      ".next/bun-compile-ctx.json": MOCK_CTX,
+      ".next/static/app.js": "// static",
+      ".next/standalone/server.js": MOCK_SERVER_JS,
+      ".next/standalone/.next/BUILD_ID": "sym-build",
+      ".next/standalone/.next/server/chunks/ssr.js": `// chunk`,
+      ".next/standalone/node_modules/next/package.json": MOCK_NEXT_PKG,
+      ".next/standalone/node_modules/next/dist/server/require-hook.js": MOCK_REQUIRE_HOOK,
+      // The .bun hoisted store: next@<ver>/node_modules/<dep> entries are
+      // symlinks to other store entries. Simulate one whose target is missing
+      // (this throws ENOENT on stat — equivalent to Windows' EPERM on locked
+      // symlinks). The real `react` package is reachable via its canonical
+      // .bun/react@<ver>/node_modules/react/ path below.
+      ".next/standalone/node_modules/.bun/next@16.2.0/node_modules/next/package.json":
+        MOCK_NEXT_PKG,
+      ".next/standalone/node_modules/.bun/react@19.0.0/node_modules/react/package.json":
+        JSON.stringify({ name: "react", version: "19.0.0" }),
+      ".next/standalone/node_modules/.bun/react@19.0.0/node_modules/react/index.js":
+        `module.exports = {};`,
+      "public/favicon.ico": "icon",
+    });
+
+    // Dangling symlink — points to a path that never exists
+    const reactLink = join(
+      standaloneDir,
+      "node_modules/.bun/next@16.2.0/node_modules/react"
+    );
+    symlinkSync(
+      join(standaloneDir, "node_modules/.bun/__missing__/node_modules/react"),
+      reactLink
+    );
+
+    expect(() =>
+      generateEntryPoint({ standaloneDir, distDir, projectDir })
+    ).not.toThrow();
+
+    // The real react (reachable via its canonical .bun path) still embeds
+    expect(
+      existsSync(join(standaloneDir, ".next/__external/react/index.js"))
     ).toBe(true);
   });
 

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -5,6 +5,7 @@ import {
   readdirSync,
   statSync,
   mkdirSync,
+  type Stats,
 } from "node:fs";
 import { join, relative } from "node:path";
 import { createHash } from "node:crypto";
@@ -13,6 +14,25 @@ interface GenerateOptions {
   standaloneDir: string;
   distDir: string;
   projectDir: string;
+}
+
+/**
+ * statSync that returns null instead of throwing on EPERM/EACCES/ENOENT.
+ * Bun's hoisted store (node_modules/.bun/<pkg>@<ver>/node_modules/<dep>) uses
+ * symlinks pointing to other entries in the same store. On Windows those
+ * targets can be locked and statSync throws EPERM (bun#4533) — leaving the
+ * symlink unwalkable. The real package files always exist at their canonical
+ * .bun/<dep>@<ver>/node_modules/<dep>/ path, so skipping the unstattable
+ * entry doesn't lose data.
+ */
+function tryStat(p: string): Stats | null {
+  try {
+    return statSync(p);
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "EPERM" || code === "EACCES" || code === "ENOENT") return null;
+    throw err;
+  }
 }
 
 /** Recursively collect all files under a directory */
@@ -24,7 +44,9 @@ function walkDir(
   if (!existsSync(dir)) return results;
   for (const entry of readdirSync(dir)) {
     const full = join(dir, entry);
-    if (statSync(full).isDirectory()) {
+    const stat = tryStat(full);
+    if (!stat) continue;
+    if (stat.isDirectory()) {
       results.push(...walkDir(full, base));
     } else {
       results.push({ absolutePath: full, relativePath: relative(base, full) });
@@ -145,7 +167,8 @@ function findServerDir(standaloneDir: string): string {
     for (const entry of readdirSync(dir)) {
       if (entry === "node_modules") continue;
       const full = join(dir, entry);
-      if (!statSync(full).isDirectory()) continue;
+      const stat = tryStat(full);
+      if (!stat || !stat.isDirectory()) continue;
       if (existsSync(join(full, "server.js"))) return full;
       const found = search(full);
       if (found) return found;
@@ -227,11 +250,13 @@ function collectExternalModules(
     for (const entry of readdirSync(dir)) {
       if (entry.startsWith(".") || entry === "next-bun-compile") continue;
       const entryPath = join(dir, entry);
-      if (!statSync(entryPath).isDirectory()) continue;
+      const stat = tryStat(entryPath);
+      if (!stat || !stat.isDirectory()) continue;
       if (entry.startsWith("@")) {
         for (const sub of readdirSync(entryPath)) {
           const subPath = join(entryPath, sub);
-          if (statSync(subPath).isDirectory()) addPkg(`${entry}/${sub}`, subPath);
+          const subStat = tryStat(subPath);
+          if (subStat && subStat.isDirectory()) addPkg(`${entry}/${sub}`, subPath);
         }
       } else {
         addPkg(entry, entryPath);
@@ -277,7 +302,8 @@ function fixModuleResolution(standaloneDir: string): void {
     if (!existsSync(compiledDir)) continue;
     for (const entry of readdirSync(compiledDir)) {
       const dir = join(compiledDir, entry);
-      if (!statSync(dir).isDirectory()) continue;
+      const stat = tryStat(dir);
+      if (!stat || !stat.isDirectory()) continue;
       const pkgJsonPath = join(dir, "package.json");
       const indexPath = join(dir, "index.js");
       if (!existsSync(pkgJsonPath) || existsSync(indexPath)) continue;


### PR DESCRIPTION
## Summary
- Bun's hoisted store puts dependency symlinks at `node_modules/.bun/<pkg>@<ver>/node_modules/<dep>` pointing into other `.bun/` entries. On Windows, `statSync` on these throws `EPERM` when the symlink target is locked ([bun#4533](https://github.com/oven-sh/bun/issues/4533)), crashing the build (see #15).
- Add `tryStat` that returns `null` on `EPERM`/`EACCES`/`ENOENT` and use it at all four `statSync` sites: `walkDir`, `findServerDir`, `collectExternalModules.scanDir`, and `fixModuleResolution`.
- Real package contents are always reachable via the canonical `.bun/<dep>@<ver>/node_modules/<dep>/` path (and `.pnpm/<dep>@<ver>/...` for pnpm), so skipping the unstattable entry doesn't lose any files.

## Test plan
- [x] New regression test scaffolds a dangling symlink at `.bun/next@<ver>/node_modules/react` (throws `ENOENT` on macOS — same code path as Windows `EPERM`) and asserts `generateEntryPoint` doesn't throw.
- [x] Test verified failing before the fix (`ENOENT: no such file or directory, stat ...`) and passing after.
- [x] All 8 tests pass; `bun run build` clean.
- [ ] Verify on Windows against the original failing project from #15.

Fixes #15