### PR TITLE
Recreate turbopack mangled-alias symlinks at runtime

### DIFF
--- a/src/generate.test.ts
+++ b/src/generate.test.ts
@@ -289,6 +289,53 @@ describe("generateEntryPoint", () => {
     ).toBe(true);
   });
 
+  test("recreates turbopack mangled-alias symlinks (.next/node_modules/<pkg>-<hash>)", () => {
+    const root = join(tmpBase, "turbopack-alias");
+    const distDir = join(root, ".next");
+    const standaloneDir = join(distDir, "standalone");
+    const projectDir = root;
+
+    scaffold(root, {
+      ".next/bun-compile-ctx.json": MOCK_CTX,
+      ".next/static/app.js": "// static",
+      ".next/standalone/server.js": MOCK_SERVER_JS,
+      ".next/standalone/.next/BUILD_ID": "alias-build",
+      // Turbopack-compiled chunk references the mangled external name
+      ".next/standalone/.next/server/chunks/ssr.js":
+        `require("sharp-457ea9eae1af1a9c");`,
+      ".next/standalone/node_modules/next/package.json": MOCK_NEXT_PKG,
+      ".next/standalone/node_modules/next/dist/server/require-hook.js": MOCK_REQUIRE_HOOK,
+      // Real sharp package lives in the .bun hoisted store
+      ".next/standalone/node_modules/.bun/sharp@0.34.5/node_modules/sharp/package.json":
+        JSON.stringify({ name: "sharp", version: "0.34.5", main: "lib/index.js" }),
+      ".next/standalone/node_modules/.bun/sharp@0.34.5/node_modules/sharp/lib/index.js":
+        "module.exports = {};",
+      "public/favicon.ico": "icon",
+    });
+
+    // Next.js creates this symlink so the mangled require() resolves at build
+    mkdirSync(join(standaloneDir, ".next/node_modules"), { recursive: true });
+    symlinkSync(
+      "../../node_modules/.bun/sharp@0.34.5/node_modules/sharp",
+      join(standaloneDir, ".next/node_modules/sharp-457ea9eae1af1a9c"),
+      "dir"
+    );
+
+    const serverDir = generateEntryPoint({ standaloneDir, distDir, projectDir });
+
+    // Canonical sharp must still be embedded (alias points to it at runtime)
+    const assets = readFileSync(join(serverDir, "assets.generated.js"), "utf-8");
+    expect(assets).toContain("sharp/lib/index.js");
+
+    // Files under the mangled-alias symlink should NOT be duplicated into the
+    // bundle — they'd double the binary footprint of every aliased package
+    expect(assets).not.toContain("sharp-457ea9eae1af1a9c/lib");
+
+    // Runtime entry must recreate the alias so require("sharp-457...") resolves
+    const entry = readFileSync(join(serverDir, "server-entry.js"), "utf-8");
+    expect(entry).toContain('["sharp-457ea9eae1af1a9c","sharp"]');
+  });
+
   test("deeply nested monorepo layout (packages/apps/web)", () => {
     const root = join(tmpBase, "deep-mono");
     const distDir = join(root, ".next");

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -4,10 +4,12 @@ import {
   existsSync,
   readdirSync,
   statSync,
+  lstatSync,
+  realpathSync,
   mkdirSync,
   type Stats,
 } from "node:fs";
-import { join, relative } from "node:path";
+import { join, relative, basename } from "node:path";
 import { createHash } from "node:crypto";
 
 interface GenerateOptions {
@@ -148,6 +150,36 @@ function generateStubs(standaloneDir: string): void {
   if (count > 0) {
     console.log(`next-bun-compile: Created ${count} module stubs`);
   }
+}
+
+/**
+ * Next.js with turbopack emits server chunks that reference externalized
+ * packages by mangled names like `sharp-457ea9eae1af1a9c`, and creates
+ * symlinks at `.next/node_modules/<mangled>` pointing to the real package
+ * so `require("sharp-457...")` resolves at runtime. The compiled binary
+ * has no filesystem, so the symlinks need to be recreated after asset
+ * extraction; embedding the symlinked files duplicates them and isn't
+ * reliable through bun's bundler.
+ */
+function findTurbopackAliases(
+  standaloneNextDir: string
+): Array<{ alias: string; target: string }> {
+  const nodeModulesDir = join(standaloneNextDir, "node_modules");
+  if (!existsSync(nodeModulesDir)) return [];
+
+  const aliases: Array<{ alias: string; target: string }> = [];
+  for (const entry of readdirSync(nodeModulesDir)) {
+    if (!/-[0-9a-f]{16}$/.test(entry)) continue;
+    const aliasPath = join(nodeModulesDir, entry);
+    try {
+      if (!lstatSync(aliasPath).isSymbolicLink()) continue;
+      const target = basename(realpathSync(aliasPath));
+      aliases.push({ alias: entry, target });
+    } catch {
+      continue;
+    }
+  }
+  return aliases;
 }
 
 /**
@@ -352,12 +384,21 @@ export function generateEntryPoint(options: GenerateOptions): string {
     urlPath: `/${f.relativePath.replace(/\\/g, "/")}`,
   }));
 
-  // Discover runtime files from standalone .next/ (BUILD_ID, manifests, server chunks)
+  // Discover runtime files from standalone .next/ (BUILD_ID, manifests, server chunks).
+  // Skip files reached through turbopack's mangled-alias symlinks — we recreate
+  // those as runtime symlinks/shims instead of embedding duplicate copies.
   const standaloneNextDir = join(serverDir, ".next");
-  const runtimeFiles = walkDir(standaloneNextDir).map((f) => ({
-    ...f,
-    urlPath: `__runtime/.next/${f.relativePath.replace(/\\/g, "/")}`,
-  }));
+  const turbopackAliases = findTurbopackAliases(standaloneNextDir);
+  const aliasNames = new Set(turbopackAliases.map((a) => a.alias));
+  const runtimeFiles = walkDir(standaloneNextDir)
+    .filter((f) => {
+      const m = f.relativePath.replace(/\\/g, "/").match(/^node_modules\/([^/]+)/);
+      return !(m && aliasNames.has(m[1]));
+    })
+    .map((f) => ({
+      ...f,
+      urlPath: `__runtime/.next/${f.relativePath.replace(/\\/g, "/")}`,
+    }));
 
   // Copy external modules into .next/__external/ so they get embedded as
   // regular file assets (JS files in node_modules/ conflict with bun's bundler).
@@ -470,6 +511,7 @@ if (Number.isNaN(keepAliveTimeout) || !Number.isFinite(keepAliveTimeout) || keep
 }
 
 const extractions = ${JSON.stringify(assetExtractions)};
+const turbopackAliases = ${JSON.stringify(turbopackAliases.map((a) => [a.alias, a.target]))};
 async function extractAssets() {
   let n = 0;
   for (const [urlPath, diskPath] of extractions) {
@@ -478,6 +520,24 @@ async function extractAssets() {
     fs.mkdirSync(path.dirname(fullPath), { recursive: true });
     const embedded = assetMap.get(urlPath);
     if (embedded) { await Bun.write(fullPath, Bun.file(embedded)); n++; }
+  }
+  for (const [alias, target] of turbopackAliases) {
+    const aliasPath = path.join(baseDir, ".next/node_modules", alias);
+    if (fs.existsSync(aliasPath)) continue;
+    fs.mkdirSync(path.dirname(aliasPath), { recursive: true });
+    try {
+      fs.symlinkSync(target, aliasPath, "dir");
+    } catch {
+      fs.mkdirSync(aliasPath, { recursive: true });
+      fs.writeFileSync(
+        path.join(aliasPath, "package.json"),
+        JSON.stringify({ name: alias, main: "index.js" })
+      );
+      fs.writeFileSync(
+        path.join(aliasPath, "index.js"),
+        "module.exports = require(" + JSON.stringify(target) + ");"
+      );
+    }
   }
   if (n > 0) console.log(\`Extracted \${n} assets\`);
 }


### PR DESCRIPTION
## Summary

Fixes runtime failure in next-bun-compile-built binaries when Next.js with turbopack externalizes packages like `sharp`:

```
Failed to load external module sharp-457ea9eae1af1a9c:
ResolveMessage: Cannot find package 'sharp-457ea9eae1af1a9c' from
  '/app/.next/server/chunks/ssr/[root-of-the-server]__0rdmvhb._.js'
```

## What was happening

Turbopack rewrites externalized requires to mangled names: `require("sharp")` → `require("sharp-457ea9eae1af1a9c")`. Next.js then creates a symlink at `.next/node_modules/sharp-457ea9eae1af1a9c → ../../node_modules/.../sharp` so the require resolves during a normal `next start`.

`walkDir` was traversing that symlink and embedding every sharp file twice — once under `__runtime/.next/node_modules/sharp-457.../...` (via the symlink) and once under `__runtime/.next/node_modules/sharp/...` (via `collectExternalModules`). Bun's bundler dedupes file embeds by content hash, so the two import paths collapsed to the same embedded asset ID and one of the `assetMap.get(url)` lookups returned `undefined`, leaving the mangled-path files unextracted at runtime.

## Fix

- New `findTurbopackAliases()` scans `.next/node_modules/` for `<name>-<16hex>` symlinks and resolves their canonical targets.
- `walkDir` output is filtered to skip files reached through those alias symlinks (no more duplicate embeds).
- Runtime `extractAssets()` recreates each alias as a real symlink, with a `require()`-shim fallback for filesystems that block symlinks.

Side benefit: smaller binary — aliased packages are no longer duplicated.

## Test plan

- [x] Added regression test that fails on `main` and passes after the fix
- [x] All 9 existing tests still pass
- [x] Verified end-to-end on the originally-failing app (remorva): compiled binary boots cleanly, homepage returns 200, no `Cannot find package` error
- [x] Runtime symlink confirmed materializes: `.next/node_modules/sharp-457ea9eae1af1a9c -> sharp`