### PR TITLE
Discover turbopack mangled aliases by grepping server chunks

### DIFF
--- a/src/generate.test.ts
+++ b/src/generate.test.ts
@@ -336,6 +336,41 @@ describe("generateEntryPoint", () => {
     expect(entry).toContain('["sharp-457ea9eae1af1a9c","sharp"]');
   });
 
+  test("discovers turbopack aliases from chunk require() literals when symlink is absent", () => {
+    // In some Linux/Docker builds, Next.js doesn't create the
+    // .next/node_modules/<mangled> symlinks even though the emitted chunks
+    // still call require("<name>-<hash>"). Discovery must fall back to
+    // grepping the chunks themselves.
+    const root = join(tmpBase, "turbopack-alias-no-symlink");
+    const distDir = join(root, ".next");
+    const standaloneDir = join(distDir, "standalone");
+    const projectDir = root;
+
+    scaffold(root, {
+      ".next/bun-compile-ctx.json": MOCK_CTX,
+      ".next/static/app.js": "// static",
+      ".next/standalone/server.js": MOCK_SERVER_JS,
+      ".next/standalone/.next/BUILD_ID": "no-symlink-build",
+      // Realistic turbopack chunk shape: thunk wraps the require call
+      ".next/standalone/.next/server/chunks/ssr/page.js":
+        `b.exports=a.x("sharp-457ea9eae1af1a9c",()=>require("sharp-457ea9eae1af1a9c"))`,
+      ".next/standalone/node_modules/next/package.json": MOCK_NEXT_PKG,
+      ".next/standalone/node_modules/next/dist/server/require-hook.js": MOCK_REQUIRE_HOOK,
+      ".next/standalone/node_modules/.bun/sharp@0.34.5/node_modules/sharp/package.json":
+        JSON.stringify({ name: "sharp", version: "0.34.5", main: "lib/index.js" }),
+      ".next/standalone/node_modules/.bun/sharp@0.34.5/node_modules/sharp/lib/index.js":
+        "module.exports = {};",
+      "public/favicon.ico": "icon",
+    });
+
+    // NOTE: no .next/node_modules/sharp-457... symlink is created
+
+    const serverDir = generateEntryPoint({ standaloneDir, distDir, projectDir });
+
+    const entry = readFileSync(join(serverDir, "server-entry.js"), "utf-8");
+    expect(entry).toContain('["sharp-457ea9eae1af1a9c","sharp"]');
+  });
+
   test("deeply nested monorepo layout (packages/apps/web)", () => {
     const root = join(tmpBase, "deep-mono");
     const distDir = join(root, ".next");

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -153,33 +153,62 @@ function generateStubs(standaloneDir: string): void {
 }
 
 /**
- * Next.js with turbopack emits server chunks that reference externalized
- * packages by mangled names like `sharp-457ea9eae1af1a9c`, and creates
- * symlinks at `.next/node_modules/<mangled>` pointing to the real package
- * so `require("sharp-457...")` resolves at runtime. The compiled binary
- * has no filesystem, so the symlinks need to be recreated after asset
- * extraction; embedding the symlinked files duplicates them and isn't
- * reliable through bun's bundler.
+ * Next.js with turbopack rewrites externalized requires to mangled names,
+ * e.g. `require("sharp")` becomes `require("sharp-457ea9eae1af1a9c")` in
+ * the emitted chunks. During `next start` Next.js relies on a symlink at
+ * `.next/node_modules/<mangled> -> ../../node_modules/<real>` for those
+ * requires to resolve. The compiled binary has no node_modules tree
+ * pre-baked on disk, so the aliases need to be materialized after asset
+ * extraction.
+ *
+ * Discovery: grep server chunks for `require("<name>-<16hex>")` literals.
+ * Works regardless of whether Next.js created the `.next/node_modules/<mangled>`
+ * symlink during build — it does on macOS but not on some Linux/Docker
+ * configurations. The canonical name is the mangled name with the trailing
+ * `-<16 hex>` content hash stripped. The build-time symlink is consulted
+ * as a fallback for aliases referenced outside literal `require()` calls.
  */
 function findTurbopackAliases(
   standaloneNextDir: string
 ): Array<{ alias: string; target: string }> {
-  const nodeModulesDir = join(standaloneNextDir, "node_modules");
-  if (!existsSync(nodeModulesDir)) return [];
+  const seen = new Map<string, string>();
 
-  const aliases: Array<{ alias: string; target: string }> = [];
-  for (const entry of readdirSync(nodeModulesDir)) {
-    if (!/-[0-9a-f]{16}$/.test(entry)) continue;
-    const aliasPath = join(nodeModulesDir, entry);
-    try {
-      if (!lstatSync(aliasPath).isSymbolicLink()) continue;
-      const target = basename(realpathSync(aliasPath));
-      aliases.push({ alias: entry, target });
-    } catch {
-      continue;
+  const serverDir = join(standaloneNextDir, "server");
+  if (existsSync(serverDir)) {
+    const re = /require\(["']([^"'\s/]+-[0-9a-f]{16})["']\)/g;
+    for (const f of walkDir(serverDir)) {
+      if (!f.absolutePath.endsWith(".js")) continue;
+      let content: string;
+      try {
+        content = readFileSync(f.absolutePath, "utf-8");
+      } catch {
+        continue;
+      }
+      let m;
+      while ((m = re.exec(content))) {
+        const alias = m[1];
+        if (seen.has(alias)) continue;
+        seen.set(alias, alias.replace(/-[0-9a-f]{16}$/, ""));
+      }
     }
   }
-  return aliases;
+
+  const nodeModulesDir = join(standaloneNextDir, "node_modules");
+  if (existsSync(nodeModulesDir)) {
+    for (const entry of readdirSync(nodeModulesDir)) {
+      if (!/-[0-9a-f]{16}$/.test(entry)) continue;
+      if (seen.has(entry)) continue;
+      const aliasPath = join(nodeModulesDir, entry);
+      try {
+        if (!lstatSync(aliasPath).isSymbolicLink()) continue;
+        seen.set(entry, basename(realpathSync(aliasPath)));
+      } catch {
+        continue;
+      }
+    }
+  }
+
+  return Array.from(seen, ([alias, target]) => ({ alias, target }));
 }
 
 /**


### PR DESCRIPTION
## Summary

Follow-up to #17. v0.6.3 discovered turbopack mangled aliases by scanning `.next/node_modules/` for `<name>-<16hex>` symlinks. That works on macOS but on some Linux/Docker builds Next.js doesn't create those symlinks, so discovery returned `[]`, no aliases were materialized at runtime, and chunks still threw:

```
Failed to load external module sharp-457ea9eae1af1a9c:
Cannot find package 'sharp-457ea9eae1af1a9c' from
  '/app/.next/server/chunks/ssr/[root-of-the-server]__0rdmvhb._.js'
```

## Fix

Switch primary discovery to grepping server chunks for `require("<name>-<16hex>")` literals. The canonical name is the prefix before the 16-hex content hash. Works regardless of whether the build-time symlinks exist. The symlink scan stays as a fallback for aliases referenced outside literal `require()` calls.

## Test plan

- [x] Added regression test that omits the build-time symlink and verifies chunk-grep discovery produces the alias mapping
- [x] All existing tests still pass (10/10)
- [x] Verified end-to-end with build-time symlinks removed (simulating the Docker failure mode): aliases discovered from chunks, runtime symlink materializes, app boots and serves 200