### PR TITLE
Materialize turbopack aliases as shim packages, not symlinks

### DIFF
--- a/src/generate.ts
+++ b/src/generate.ts
@@ -553,20 +553,15 @@ async function extractAssets() {
   for (const [alias, target] of turbopackAliases) {
     const aliasPath = path.join(baseDir, ".next/node_modules", alias);
     if (fs.existsSync(aliasPath)) continue;
-    fs.mkdirSync(path.dirname(aliasPath), { recursive: true });
-    try {
-      fs.symlinkSync(target, aliasPath, "dir");
-    } catch {
-      fs.mkdirSync(aliasPath, { recursive: true });
-      fs.writeFileSync(
-        path.join(aliasPath, "package.json"),
-        JSON.stringify({ name: alias, main: "index.js" })
-      );
-      fs.writeFileSync(
-        path.join(aliasPath, "index.js"),
-        "module.exports = require(" + JSON.stringify(target) + ");"
-      );
-    }
+    fs.mkdirSync(aliasPath, { recursive: true });
+    fs.writeFileSync(
+      path.join(aliasPath, "package.json"),
+      JSON.stringify({ name: alias, main: "index.js" })
+    );
+    fs.writeFileSync(
+      path.join(aliasPath, "index.js"),
+      "module.exports = require(" + JSON.stringify(target) + ");"
+    );
   }
   if (n > 0) console.log(\`Extracted \${n} assets\`);
 }


### PR DESCRIPTION
## Summary

Follow-up to #18. v0.6.4 created each turbopack alias as a symlink (e.g. `sharp-457... -> sharp`). The symlink lands on disk correctly, but on Linux under Docker the compiled bun binary's resolver doesn't follow it — `require(\"sharp-457...\")` still throws `Cannot find package`. Works on macOS, fails on Linux Docker.

## Fix

Replace the symlink with a real directory shim:
- `package.json` — `{ \"name\": \"<alias>\", \"main\": \"index.js\" }`
- `index.js` — `module.exports = require(\"<canonical>\")`

Plain CommonJS resolution chain; no symlink-following required. Adds one require hop but resolves reliably under bun's compiled-binary resolver on every platform.

Subpath imports (`require(\"<alias>/lib/foo\")`) aren't supported by the shim — in practice turbopack only emits top-level externalized package requires, so this hasn't surfaced.

## Test plan

- [x] All 10 tests pass — the alias map literal assertion still holds
- [x] Verified locally: regenerated standalone (without build-time symlinks, simulating Docker), boot creates the shim directory, `require(\"sharp-457...\")` resolution chain succeeds