### PR TITLE
Resolve turbopack alias subpaths and shim via relative require

### DIFF
--- a/src/generate.test.ts
+++ b/src/generate.test.ts
@@ -333,7 +333,7 @@ describe("generateEntryPoint", () => {
 
     // Runtime entry must recreate the alias so require("sharp-457...") resolves
     const entry = readFileSync(join(serverDir, "server-entry.js"), "utf-8");
-    expect(entry).toContain('["sharp-457ea9eae1af1a9c","sharp"]');
+    expect(entry).toContain('["sharp-457ea9eae1af1a9c","sharp",[]]');
   });
 
   test("discovers turbopack aliases from chunk require() literals when symlink is absent", () => {
@@ -368,7 +368,52 @@ describe("generateEntryPoint", () => {
     const serverDir = generateEntryPoint({ standaloneDir, distDir, projectDir });
 
     const entry = readFileSync(join(serverDir, "server-entry.js"), "utf-8");
-    expect(entry).toContain('["sharp-457ea9eae1af1a9c","sharp"]');
+    expect(entry).toContain('["sharp-457ea9eae1af1a9c","sharp",[]]');
+  });
+
+  test("collects subpath references from import()/require() in chunks", () => {
+    // Turbopack can emit subpath imports against mangled aliases, e.g.
+    // `import("prettier-285d8f1d6bb5f650/plugins/html")`. The runtime
+    // shim must materialize a file at the subpath so it resolves.
+    const root = join(tmpBase, "turbopack-alias-subpath");
+    const distDir = join(root, ".next");
+    const standaloneDir = join(distDir, "standalone");
+    const projectDir = root;
+
+    scaffold(root, {
+      ".next/bun-compile-ctx.json": MOCK_CTX,
+      ".next/static/app.js": "// static",
+      ".next/standalone/server.js": MOCK_SERVER_JS,
+      ".next/standalone/.next/BUILD_ID": "subpath-build",
+      // Realistic chunk shape: turbopack's runtime helpers pass mangled
+      // ids as bare strings — `a.x(...)` for externalRequire, `a.y(...)` for
+      // externalImport. No literal require()/import() wraps the id, which
+      // is the case the regex needs to handle.
+      ".next/standalone/.next/server/chunks/ssr/page.js":
+        `b.exports=a.x("sharp-457ea9eae1af1a9c",()=>require("sharp-457ea9eae1af1a9c"));\n` +
+        `let p=await a.y("prettier-285d8f1d6bb5f650/plugins/html");`,
+      ".next/standalone/node_modules/next/package.json": MOCK_NEXT_PKG,
+      ".next/standalone/node_modules/next/dist/server/require-hook.js": MOCK_REQUIRE_HOOK,
+      ".next/standalone/node_modules/.bun/sharp@0.34.5/node_modules/sharp/package.json":
+        JSON.stringify({ name: "sharp", main: "index.js" }),
+      ".next/standalone/node_modules/.bun/sharp@0.34.5/node_modules/sharp/index.js":
+        "module.exports = {};",
+      ".next/standalone/node_modules/.bun/prettier@3.8.4/node_modules/prettier/package.json":
+        JSON.stringify({ name: "prettier" }),
+      ".next/standalone/node_modules/.bun/prettier@3.8.4/node_modules/prettier/plugins/html.js":
+        "module.exports = {};",
+      "public/favicon.ico": "icon",
+    });
+
+    const serverDir = generateEntryPoint({ standaloneDir, distDir, projectDir });
+    const entry = readFileSync(join(serverDir, "server-entry.js"), "utf-8");
+
+    // Sharp: no subpaths used
+    expect(entry).toContain('["sharp-457ea9eae1af1a9c","sharp",[]]');
+    // Prettier: the html subpath was discovered
+    expect(entry).toContain(
+      '["prettier-285d8f1d6bb5f650","prettier",["plugins/html"]]'
+    );
   });
 
   test("deeply nested monorepo layout (packages/apps/web)", () => {

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -170,12 +170,33 @@ function generateStubs(standaloneDir: string): void {
  */
 function findTurbopackAliases(
   standaloneNextDir: string
-): Array<{ alias: string; target: string }> {
-  const seen = new Map<string, string>();
+): Array<{ alias: string; target: string; subpaths: string[] }> {
+  const seen = new Map<
+    string,
+    { target: string; subpaths: Set<string> }
+  >();
+
+  const ensure = (alias: string) => {
+    let entry = seen.get(alias);
+    if (!entry) {
+      entry = {
+        target: alias.replace(/-[0-9a-f]{16}$/, ""),
+        subpaths: new Set(),
+      };
+      seen.set(alias, entry);
+    }
+    return entry;
+  };
 
   const serverDir = join(standaloneNextDir, "server");
   if (existsSync(serverDir)) {
-    const re = /require\(["']([^"'\s/]+-[0-9a-f]{16})["']\)/g;
+    // Match any string literal of the shape `"<name>-<16 hex>[/<subpath>]"`.
+    // Turbopack passes mangled ids to its runtime helpers as bare strings
+    // (e.g. `a.y("prettier-.../plugins/html")`), so a regex anchored to
+    // `require(...)`/`import(...)` misses the externalImport call sites.
+    // The 16-hex suffix is selective enough that false positives in JS
+    // chunks are vanishingly unlikely.
+    const re = /["']([^"'\s/]+-[0-9a-f]{16})(?:\/([^"'\s]+))?["']/g;
     for (const f of walkDir(serverDir)) {
       if (!f.absolutePath.endsWith(".js")) continue;
       let content: string;
@@ -186,29 +207,35 @@ function findTurbopackAliases(
       }
       let m;
       while ((m = re.exec(content))) {
-        const alias = m[1];
-        if (seen.has(alias)) continue;
-        seen.set(alias, alias.replace(/-[0-9a-f]{16}$/, ""));
+        const entry = ensure(m[1]);
+        if (m[2]) entry.subpaths.add(m[2]);
       }
     }
   }
 
   const nodeModulesDir = join(standaloneNextDir, "node_modules");
   if (existsSync(nodeModulesDir)) {
-    for (const entry of readdirSync(nodeModulesDir)) {
-      if (!/-[0-9a-f]{16}$/.test(entry)) continue;
-      if (seen.has(entry)) continue;
-      const aliasPath = join(nodeModulesDir, entry);
+    for (const name of readdirSync(nodeModulesDir)) {
+      if (!/-[0-9a-f]{16}$/.test(name)) continue;
+      if (seen.has(name)) continue;
+      const aliasPath = join(nodeModulesDir, name);
       try {
         if (!lstatSync(aliasPath).isSymbolicLink()) continue;
-        seen.set(entry, basename(realpathSync(aliasPath)));
+        seen.set(name, {
+          target: basename(realpathSync(aliasPath)),
+          subpaths: new Set(),
+        });
       } catch {
         continue;
       }
     }
   }
 
-  return Array.from(seen, ([alias, target]) => ({ alias, target }));
+  return Array.from(seen, ([alias, { target, subpaths }]) => ({
+    alias,
+    target,
+    subpaths: Array.from(subpaths),
+  }));
 }
 
 /**
@@ -540,7 +567,7 @@ if (Number.isNaN(keepAliveTimeout) || !Number.isFinite(keepAliveTimeout) || keep
 }
 
 const extractions = ${JSON.stringify(assetExtractions)};
-const turbopackAliases = ${JSON.stringify(turbopackAliases.map((a) => [a.alias, a.target]))};
+const turbopackAliases = ${JSON.stringify(turbopackAliases.map((a) => [a.alias, a.target, a.subpaths]))};
 async function extractAssets() {
   let n = 0;
   for (const [urlPath, diskPath] of extractions) {
@@ -550,18 +577,34 @@ async function extractAssets() {
     const embedded = assetMap.get(urlPath);
     if (embedded) { await Bun.write(fullPath, Bun.file(embedded)); n++; }
   }
-  for (const [alias, target] of turbopackAliases) {
+  for (const [alias, target, subpaths] of turbopackAliases) {
     const aliasPath = path.join(baseDir, ".next/node_modules", alias);
-    if (fs.existsSync(aliasPath)) continue;
-    fs.mkdirSync(aliasPath, { recursive: true });
-    fs.writeFileSync(
-      path.join(aliasPath, "package.json"),
-      JSON.stringify({ name: alias, main: "index.js" })
-    );
-    fs.writeFileSync(
-      path.join(aliasPath, "index.js"),
-      "module.exports = require(" + JSON.stringify(target) + ");"
-    );
+    if (!fs.existsSync(aliasPath)) {
+      fs.mkdirSync(aliasPath, { recursive: true });
+      fs.writeFileSync(
+        path.join(aliasPath, "package.json"),
+        JSON.stringify({ name: alias, main: "index.js" })
+      );
+      // Relative path bypasses bun's package-name resolver, which doesn't
+      // walk up to the parent node_modules from inside an alias directory.
+      fs.writeFileSync(
+        path.join(aliasPath, "index.js"),
+        "module.exports = require(" + JSON.stringify("../" + target) + ");"
+      );
+    }
+    for (const sub of subpaths) {
+      const subKey = sub.replace(/\\.js$/, "");
+      const shimFile = path.join(aliasPath, subKey + ".js");
+      if (fs.existsSync(shimFile)) continue;
+      fs.mkdirSync(path.dirname(shimFile), { recursive: true });
+      const canonicalFile = path.join(baseDir, ".next/node_modules", target, subKey);
+      const rel = path.relative(path.dirname(shimFile), canonicalFile);
+      const spec = rel.startsWith(".") ? rel : "./" + rel;
+      fs.writeFileSync(
+        shimFile,
+        "module.exports = require(" + JSON.stringify(spec) + ");"
+      );
+    }
   }
   if (n > 0) console.log(\`Extracted \${n} assets\`);
 }


### PR DESCRIPTION
## Summary

Two follow-up issues to #19, surfaced when v0.6.5 hit a real chunk:

**1. Bun's resolver doesn't walk up node_modules from inside an alias dir.**
v0.6.5's shim did \`module.exports = require(\"<canonical>\")\`. From \`.next/node_modules/<alias>/index.js\`, bun's compiled-binary resolver refused to walk up to find \`<canonical>\` in the parent \`node_modules\`. Result: \`Cannot find package '<canonical>' from '.next/node_modules/<alias>/index.js'\`.

Fix: relative require — \`module.exports = require(\"../<canonical>\")\`. Path-based, no package lookup.

**2. Turbopack passes mangled ids to runtime helpers without literal require/import wrappers.**
The runtime emits \`a.y(\"prettier-.../plugins/html\")\` for externalImport calls. The old regex only matched ids inside \`require(...)\`/\`import(...)\`, so subpath references were dropped.

Fix: match any bare string literal of shape \`\"<name>-<16hex>[/sub/path]\"\` — the 16-hex suffix is selective enough that false positives in JS chunks are vanishingly unlikely. Discovered subpaths get their own shim file at the matching path, each re-exporting via a relative require so the same path-based resolution applies.

## Test plan

- [x] Updated subpath test to use the realistic \`a.y(...)\` chunk shape rather than literal \`import()\` — this catches the regression from issue #2 above
- [x] All 11 tests pass
- [x] Verified end-to-end locally: alias resolution succeeds, subpath shim files materialize, the externalRequire/externalImport calls in the chunks now resolve through the shim chain to the canonical packages