### PR TITLE
Use absolute paths in turbopack-alias shims

### DIFF
--- a/src/generate.ts
+++ b/src/generate.ts
@@ -585,11 +585,13 @@ async function extractAssets() {
         path.join(aliasPath, "package.json"),
         JSON.stringify({ name: alias, main: "index.js" })
       );
-      // Relative path bypasses bun's package-name resolver, which doesn't
-      // walk up to the parent node_modules from inside an alias directory.
+      // Absolute path. bun's compiled-binary resolver won't traverse "."/".."
+      // segments out of a dynamically-written shim (presumably tied to the
+      // module's original compile-time location, not its on-disk path), so
+      // a literal absolute target is the only thing that resolves reliably.
       fs.writeFileSync(
         path.join(aliasPath, "index.js"),
-        "module.exports = require(" + JSON.stringify("../" + target) + ");"
+        "module.exports = require(" + JSON.stringify(path.join(baseDir, ".next/node_modules", target)) + ");"
       );
     }
     for (const sub of subpaths) {
@@ -597,12 +599,9 @@ async function extractAssets() {
       const shimFile = path.join(aliasPath, subKey + ".js");
       if (fs.existsSync(shimFile)) continue;
       fs.mkdirSync(path.dirname(shimFile), { recursive: true });
-      const canonicalFile = path.join(baseDir, ".next/node_modules", target, subKey);
-      const rel = path.relative(path.dirname(shimFile), canonicalFile);
-      const spec = rel.startsWith(".") ? rel : "./" + rel;
       fs.writeFileSync(
         shimFile,
-        "module.exports = require(" + JSON.stringify(spec) + ");"
+        "module.exports = require(" + JSON.stringify(path.join(baseDir, ".next/node_modules", target, subKey)) + ");"
       );
     }
   }


### PR DESCRIPTION
## Summary

Follow-up to #20. v0.6.6 shipped relative-require shims (\`module.exports = require(\"../<canonical>\")\`) to bypass bun's package-name walk-up. Field reports show bun's compiled-binary resolver still throws \`Cannot find module '../<canonical>'\` from the shim file, even when the canonical target is right there on disk (verified via \`kubectl debug\`):

\`\`\`
ResolveMessage: Cannot find module '../sharp' from
  '/app/.next/node_modules/sharp-457ea9eae1af1a9c/index.js'
\`\`\`

Bun appears to anchor \".\"/\"..\" against some compile-time location rather than the dynamically-written file's actual on-disk path, breaking relative resolution from shims that didn't exist at compile time.

## Fix

Embed the literal absolute canonical path at shim creation time:

\`\`\`js
// .next/node_modules/sharp-457.../index.js
module.exports = require(\"/app/.next/node_modules/sharp\")
\`\`\`

Absolute paths skip relative resolution entirely. Both root and subpath shims switch to this form.

Side effect: the shim is anchored to the boot-time \`baseDir\`. In normal single-process container deployments \`baseDir\` is constant per pod, so this is fine; relocating the binary mid-runtime would invalidate the shim, but that isn't a supported workflow.

## Test plan

- [x] All 11 tests pass (assertions check the alias-map metadata, which is unchanged)
- [x] Regenerated a binary locally and confirmed shim content is now an absolute path string