### PR TITLE
Rewrite turbopack mangled-alias references in chunks at build time

### DIFF
--- a/src/generate.test.ts
+++ b/src/generate.test.ts
@@ -289,107 +289,28 @@ describe("generateEntryPoint", () => {
     ).toBe(true);
   });
 
-  test("recreates turbopack mangled-alias symlinks (.next/node_modules/<pkg>-<hash>)", () => {
-    const root = join(tmpBase, "turbopack-alias");
+  test("rewrites turbopack mangled-alias references in server chunks", () => {
+    // Turbopack emits chunks that reference externalized packages by mangled
+    // names like `sharp-457ea9eae1af1a9c`. bun's compiled-binary resolver
+    // can't navigate any shim placed under `.next/node_modules/<mangled>/`,
+    // so the build rewrites the chunks themselves to point at the canonical
+    // names — `require("sharp")` instead of `require("sharp-457...")`. Then
+    // bun's standard node_modules walk from the chunk's on-disk location
+    // resolves cleanly.
+    const root = join(tmpBase, "turbopack-alias-rewrite");
     const distDir = join(root, ".next");
     const standaloneDir = join(distDir, "standalone");
     const projectDir = root;
 
+    const chunkPath =
+      ".next/standalone/.next/server/chunks/ssr/[root-of-the-server].js";
     scaffold(root, {
       ".next/bun-compile-ctx.json": MOCK_CTX,
       ".next/static/app.js": "// static",
       ".next/standalone/server.js": MOCK_SERVER_JS,
-      ".next/standalone/.next/BUILD_ID": "alias-build",
-      // Turbopack-compiled chunk references the mangled external name
-      ".next/standalone/.next/server/chunks/ssr.js":
-        `require("sharp-457ea9eae1af1a9c");`,
-      ".next/standalone/node_modules/next/package.json": MOCK_NEXT_PKG,
-      ".next/standalone/node_modules/next/dist/server/require-hook.js": MOCK_REQUIRE_HOOK,
-      // Real sharp package lives in the .bun hoisted store
-      ".next/standalone/node_modules/.bun/sharp@0.34.5/node_modules/sharp/package.json":
-        JSON.stringify({ name: "sharp", version: "0.34.5", main: "lib/index.js" }),
-      ".next/standalone/node_modules/.bun/sharp@0.34.5/node_modules/sharp/lib/index.js":
-        "module.exports = {};",
-      "public/favicon.ico": "icon",
-    });
-
-    // Next.js creates this symlink so the mangled require() resolves at build
-    mkdirSync(join(standaloneDir, ".next/node_modules"), { recursive: true });
-    symlinkSync(
-      "../../node_modules/.bun/sharp@0.34.5/node_modules/sharp",
-      join(standaloneDir, ".next/node_modules/sharp-457ea9eae1af1a9c"),
-      "dir"
-    );
-
-    const serverDir = generateEntryPoint({ standaloneDir, distDir, projectDir });
-
-    // Canonical sharp must still be embedded (alias points to it at runtime)
-    const assets = readFileSync(join(serverDir, "assets.generated.js"), "utf-8");
-    expect(assets).toContain("sharp/lib/index.js");
-
-    // Files under the mangled-alias symlink should NOT be duplicated into the
-    // bundle — they'd double the binary footprint of every aliased package
-    expect(assets).not.toContain("sharp-457ea9eae1af1a9c/lib");
-
-    // Runtime entry must recreate the alias so require("sharp-457...") resolves
-    const entry = readFileSync(join(serverDir, "server-entry.js"), "utf-8");
-    expect(entry).toContain('["sharp-457ea9eae1af1a9c","sharp",[]]');
-  });
-
-  test("discovers turbopack aliases from chunk require() literals when symlink is absent", () => {
-    // In some Linux/Docker builds, Next.js doesn't create the
-    // .next/node_modules/<mangled> symlinks even though the emitted chunks
-    // still call require("<name>-<hash>"). Discovery must fall back to
-    // grepping the chunks themselves.
-    const root = join(tmpBase, "turbopack-alias-no-symlink");
-    const distDir = join(root, ".next");
-    const standaloneDir = join(distDir, "standalone");
-    const projectDir = root;
-
-    scaffold(root, {
-      ".next/bun-compile-ctx.json": MOCK_CTX,
-      ".next/static/app.js": "// static",
-      ".next/standalone/server.js": MOCK_SERVER_JS,
-      ".next/standalone/.next/BUILD_ID": "no-symlink-build",
-      // Realistic turbopack chunk shape: thunk wraps the require call
-      ".next/standalone/.next/server/chunks/ssr/page.js":
-        `b.exports=a.x("sharp-457ea9eae1af1a9c",()=>require("sharp-457ea9eae1af1a9c"))`,
-      ".next/standalone/node_modules/next/package.json": MOCK_NEXT_PKG,
-      ".next/standalone/node_modules/next/dist/server/require-hook.js": MOCK_REQUIRE_HOOK,
-      ".next/standalone/node_modules/.bun/sharp@0.34.5/node_modules/sharp/package.json":
-        JSON.stringify({ name: "sharp", version: "0.34.5", main: "lib/index.js" }),
-      ".next/standalone/node_modules/.bun/sharp@0.34.5/node_modules/sharp/lib/index.js":
-        "module.exports = {};",
-      "public/favicon.ico": "icon",
-    });
-
-    // NOTE: no .next/node_modules/sharp-457... symlink is created
-
-    const serverDir = generateEntryPoint({ standaloneDir, distDir, projectDir });
-
-    const entry = readFileSync(join(serverDir, "server-entry.js"), "utf-8");
-    expect(entry).toContain('["sharp-457ea9eae1af1a9c","sharp",[]]');
-  });
-
-  test("collects subpath references from import()/require() in chunks", () => {
-    // Turbopack can emit subpath imports against mangled aliases, e.g.
-    // `import("prettier-285d8f1d6bb5f650/plugins/html")`. The runtime
-    // shim must materialize a file at the subpath so it resolves.
-    const root = join(tmpBase, "turbopack-alias-subpath");
-    const distDir = join(root, ".next");
-    const standaloneDir = join(distDir, "standalone");
-    const projectDir = root;
-
-    scaffold(root, {
-      ".next/bun-compile-ctx.json": MOCK_CTX,
-      ".next/static/app.js": "// static",
-      ".next/standalone/server.js": MOCK_SERVER_JS,
-      ".next/standalone/.next/BUILD_ID": "subpath-build",
-      // Realistic chunk shape: turbopack's runtime helpers pass mangled
-      // ids as bare strings — `a.x(...)` for externalRequire, `a.y(...)` for
-      // externalImport. No literal require()/import() wraps the id, which
-      // is the case the regex needs to handle.
-      ".next/standalone/.next/server/chunks/ssr/page.js":
+      ".next/standalone/.next/BUILD_ID": "rewrite-build",
+      // Realistic chunk shape: turbopack helpers (a.x/a.y) and a literal require
+      [chunkPath]:
         `b.exports=a.x("sharp-457ea9eae1af1a9c",()=>require("sharp-457ea9eae1af1a9c"));\n` +
         `let p=await a.y("prettier-285d8f1d6bb5f650/plugins/html");`,
       ".next/standalone/node_modules/next/package.json": MOCK_NEXT_PKG,
@@ -405,15 +326,62 @@ describe("generateEntryPoint", () => {
       "public/favicon.ico": "icon",
     });
 
-    const serverDir = generateEntryPoint({ standaloneDir, distDir, projectDir });
-    const entry = readFileSync(join(serverDir, "server-entry.js"), "utf-8");
+    generateEntryPoint({ standaloneDir, distDir, projectDir });
 
-    // Sharp: no subpaths used
-    expect(entry).toContain('["sharp-457ea9eae1af1a9c","sharp",[]]');
-    // Prettier: the html subpath was discovered
-    expect(entry).toContain(
-      '["prettier-285d8f1d6bb5f650","prettier",["plugins/html"]]'
-    );
+    const chunk = readFileSync(join(root, chunkPath), "utf-8");
+    // Mangled references gone
+    expect(chunk).not.toContain("sharp-457ea9eae1af1a9c");
+    expect(chunk).not.toContain("prettier-285d8f1d6bb5f650");
+    // Canonical references in their place
+    expect(chunk).toContain('a.x("sharp"');
+    expect(chunk).toContain('require("sharp")');
+    expect(chunk).toContain('a.y("prettier/plugins/html")');
+
+    // Canonical packages still embedded so the rewritten requires resolve
+    const assets = readFileSync(join(standaloneDir, "assets.generated.js"), "utf-8");
+    expect(assets).toContain("sharp/index.js");
+    expect(assets).toContain("prettier/plugins/html.js");
+
+    // No runtime alias map left behind
+    const entry = readFileSync(join(standaloneDir, "server-entry.js"), "utf-8");
+    expect(entry).not.toContain("turbopackAliases");
+  });
+
+  test("discovers aliases from chunk literals even without build-time symlinks", () => {
+    // On some Linux/Docker builds, Next.js doesn't create the
+    // .next/node_modules/<mangled> symlinks. Discovery must fall back to
+    // scanning the chunks themselves; otherwise the rewrite pass produces
+    // no changes and the chunks still reference the mangled names.
+    const root = join(tmpBase, "turbopack-alias-no-symlink");
+    const distDir = join(root, ".next");
+    const standaloneDir = join(distDir, "standalone");
+    const projectDir = root;
+
+    const chunkPath = ".next/standalone/.next/server/chunks/ssr/page.js";
+    scaffold(root, {
+      ".next/bun-compile-ctx.json": MOCK_CTX,
+      ".next/static/app.js": "// static",
+      ".next/standalone/server.js": MOCK_SERVER_JS,
+      ".next/standalone/.next/BUILD_ID": "no-symlink-build",
+      [chunkPath]:
+        `b.exports=a.x("sharp-457ea9eae1af1a9c",()=>require("sharp-457ea9eae1af1a9c"))`,
+      ".next/standalone/node_modules/next/package.json": MOCK_NEXT_PKG,
+      ".next/standalone/node_modules/next/dist/server/require-hook.js": MOCK_REQUIRE_HOOK,
+      ".next/standalone/node_modules/.bun/sharp@0.34.5/node_modules/sharp/package.json":
+        JSON.stringify({ name: "sharp", main: "index.js" }),
+      ".next/standalone/node_modules/.bun/sharp@0.34.5/node_modules/sharp/index.js":
+        "module.exports = {};",
+      "public/favicon.ico": "icon",
+    });
+
+    // No `.next/node_modules/sharp-457...` symlink — discovery must come
+    // from the chunk literal scan alone.
+
+    generateEntryPoint({ standaloneDir, distDir, projectDir });
+
+    const chunk = readFileSync(join(root, chunkPath), "utf-8");
+    expect(chunk).not.toContain("sharp-457ea9eae1af1a9c");
+    expect(chunk).toContain('require("sharp")');
   });
 
   test("deeply nested monorepo layout (packages/apps/web)", () => {

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -155,48 +155,35 @@ function generateStubs(standaloneDir: string): void {
 /**
  * Next.js with turbopack rewrites externalized requires to mangled names,
  * e.g. `require("sharp")` becomes `require("sharp-457ea9eae1af1a9c")` in
- * the emitted chunks. During `next start` Next.js relies on a symlink at
- * `.next/node_modules/<mangled> -> ../../node_modules/<real>` for those
- * requires to resolve. The compiled binary has no node_modules tree
- * pre-baked on disk, so the aliases need to be materialized after asset
- * extraction.
+ * the emitted chunks, and Next.js writes a `.next/node_modules/<mangled>`
+ * symlink so `next start` resolves them. The compiled bun binary's
+ * resolver, however, won't resolve those mangled names from any kind of
+ * shim placed in `.next/node_modules/`: relative paths, absolute paths,
+ * directory paths, and package-name lookups have all failed in different
+ * ways in the compiled-binary code path.
  *
- * Discovery: grep server chunks for `require("<name>-<16hex>")` literals.
- * Works regardless of whether Next.js created the `.next/node_modules/<mangled>`
- * symlink during build — it does on macOS but not on some Linux/Docker
- * configurations. The canonical name is the mangled name with the trailing
- * `-<16 hex>` content hash stripped. The build-time symlink is consulted
- * as a fallback for aliases referenced outside literal `require()` calls.
+ * Solution: rewrite the chunks themselves before embedding. Every literal
+ * occurrence of `"<mangled>"` and `"<mangled>/<sub>"` in the chunk text
+ * is replaced with `"<canonical>"` / `"<canonical>/<sub>"`. The chunks
+ * then call `require("sharp")` / `import("prettier/plugins/html")`
+ * directly, which bun resolves through its normal node_modules walk from
+ * the chunk's on-disk location — the same path that successfully found
+ * the alias shim in earlier iterations.
+ *
+ * Discovery: scan chunks for `"<name>-<16 hex>[/<subpath>]"` string
+ * literals. The 16-hex content hash is selective enough that false
+ * positives in JS chunks are vanishingly unlikely. Build-time symlinks
+ * in `.next/node_modules/` are consulted as a secondary source for
+ * aliases that don't show up in any string literal.
  */
 function findTurbopackAliases(
   standaloneNextDir: string
-): Array<{ alias: string; target: string; subpaths: string[] }> {
-  const seen = new Map<
-    string,
-    { target: string; subpaths: Set<string> }
-  >();
-
-  const ensure = (alias: string) => {
-    let entry = seen.get(alias);
-    if (!entry) {
-      entry = {
-        target: alias.replace(/-[0-9a-f]{16}$/, ""),
-        subpaths: new Set(),
-      };
-      seen.set(alias, entry);
-    }
-    return entry;
-  };
+): Array<{ alias: string; target: string }> {
+  const seen = new Map<string, string>();
 
   const serverDir = join(standaloneNextDir, "server");
   if (existsSync(serverDir)) {
-    // Match any string literal of the shape `"<name>-<16 hex>[/<subpath>]"`.
-    // Turbopack passes mangled ids to its runtime helpers as bare strings
-    // (e.g. `a.y("prettier-.../plugins/html")`), so a regex anchored to
-    // `require(...)`/`import(...)` misses the externalImport call sites.
-    // The 16-hex suffix is selective enough that false positives in JS
-    // chunks are vanishingly unlikely.
-    const re = /["']([^"'\s/]+-[0-9a-f]{16})(?:\/([^"'\s]+))?["']/g;
+    const re = /["']([^"'\s/]+-[0-9a-f]{16})(?:\/[^"'\s]+)?["']/g;
     for (const f of walkDir(serverDir)) {
       if (!f.absolutePath.endsWith(".js")) continue;
       let content: string;
@@ -207,8 +194,9 @@ function findTurbopackAliases(
       }
       let m;
       while ((m = re.exec(content))) {
-        const entry = ensure(m[1]);
-        if (m[2]) entry.subpaths.add(m[2]);
+        const alias = m[1];
+        if (seen.has(alias)) continue;
+        seen.set(alias, alias.replace(/-[0-9a-f]{16}$/, ""));
       }
     }
   }
@@ -221,21 +209,57 @@ function findTurbopackAliases(
       const aliasPath = join(nodeModulesDir, name);
       try {
         if (!lstatSync(aliasPath).isSymbolicLink()) continue;
-        seen.set(name, {
-          target: basename(realpathSync(aliasPath)),
-          subpaths: new Set(),
-        });
+        seen.set(name, basename(realpathSync(aliasPath)));
       } catch {
         continue;
       }
     }
   }
 
-  return Array.from(seen, ([alias, { target, subpaths }]) => ({
-    alias,
-    target,
-    subpaths: Array.from(subpaths),
-  }));
+  return Array.from(seen, ([alias, target]) => ({ alias, target }));
+}
+
+/**
+ * Rewrite every literal `"<alias>"` reference in the server chunks to its
+ * canonical name. After this pass, the chunks no longer reference the
+ * mangled aliases at all, so no `.next/node_modules/<alias>/` shim is
+ * needed at runtime — the chunk's own `require(...)`/`import(...)` calls
+ * resolve directly against the canonical packages extracted by
+ * `collectExternalModules`.
+ */
+function rewriteTurbopackAliases(
+  standaloneNextDir: string,
+  aliases: Array<{ alias: string; target: string }>
+): void {
+  if (aliases.length === 0) return;
+  const serverDir = join(standaloneNextDir, "server");
+  if (!existsSync(serverDir)) return;
+  const escape = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const pattern = new RegExp(
+    "([\"'])(" + aliases.map((a) => escape(a.alias)).join("|") + ")(?=[/\"'])",
+    "g"
+  );
+  const targetByAlias = new Map(aliases.map((a) => [a.alias, a.target]));
+  let rewritten = 0;
+  for (const f of walkDir(serverDir)) {
+    if (!f.absolutePath.endsWith(".js")) continue;
+    let content: string;
+    try {
+      content = readFileSync(f.absolutePath, "utf-8");
+    } catch {
+      continue;
+    }
+    const next = content.replace(pattern, (_m, q, alias) => q + targetByAlias.get(alias)!);
+    if (next !== content) {
+      writeFileSync(f.absolutePath, next);
+      rewritten++;
+    }
+  }
+  if (rewritten > 0) {
+    console.log(
+      `next-bun-compile: Rewrote turbopack-mangled aliases in ${rewritten} server chunks`
+    );
+  }
 }
 
 /**
@@ -440,14 +464,19 @@ export function generateEntryPoint(options: GenerateOptions): string {
     urlPath: `/${f.relativePath.replace(/\\/g, "/")}`,
   }));
 
-  // Discover runtime files from standalone .next/ (BUILD_ID, manifests, server chunks).
-  // Skip files reached through turbopack's mangled-alias symlinks — we recreate
-  // those as runtime symlinks/shims instead of embedding duplicate copies.
+  // Rewrite turbopack-mangled alias references in server chunks before
+  // anything else reads the chunks — discovery and embedding both rely on
+  // the rewritten content. After this pass the chunks reference the
+  // canonical package names directly, and no alias shim is needed.
   const standaloneNextDir = join(serverDir, ".next");
   const turbopackAliases = findTurbopackAliases(standaloneNextDir);
+  rewriteTurbopackAliases(standaloneNextDir, turbopackAliases);
   const aliasNames = new Set(turbopackAliases.map((a) => a.alias));
   const runtimeFiles = walkDir(standaloneNextDir)
     .filter((f) => {
+      // Skip files reached through alias symlinks — the canonical files are
+      // already extracted by collectExternalModules, and the chunks no
+      // longer reference the alias paths after rewriteTurbopackAliases.
       const m = f.relativePath.replace(/\\/g, "/").match(/^node_modules\/([^/]+)/);
       return !(m && aliasNames.has(m[1]));
     })
@@ -567,7 +596,6 @@ if (Number.isNaN(keepAliveTimeout) || !Number.isFinite(keepAliveTimeout) || keep
 }
 
 const extractions = ${JSON.stringify(assetExtractions)};
-const turbopackAliases = ${JSON.stringify(turbopackAliases.map((a) => [a.alias, a.target, a.subpaths]))};
 async function extractAssets() {
   let n = 0;
   for (const [urlPath, diskPath] of extractions) {
@@ -576,34 +604,6 @@ async function extractAssets() {
     fs.mkdirSync(path.dirname(fullPath), { recursive: true });
     const embedded = assetMap.get(urlPath);
     if (embedded) { await Bun.write(fullPath, Bun.file(embedded)); n++; }
-  }
-  for (const [alias, target, subpaths] of turbopackAliases) {
-    const aliasPath = path.join(baseDir, ".next/node_modules", alias);
-    if (!fs.existsSync(aliasPath)) {
-      fs.mkdirSync(aliasPath, { recursive: true });
-      fs.writeFileSync(
-        path.join(aliasPath, "package.json"),
-        JSON.stringify({ name: alias, main: "index.js" })
-      );
-      // Absolute path. bun's compiled-binary resolver won't traverse "."/".."
-      // segments out of a dynamically-written shim (presumably tied to the
-      // module's original compile-time location, not its on-disk path), so
-      // a literal absolute target is the only thing that resolves reliably.
-      fs.writeFileSync(
-        path.join(aliasPath, "index.js"),
-        "module.exports = require(" + JSON.stringify(path.join(baseDir, ".next/node_modules", target)) + ");"
-      );
-    }
-    for (const sub of subpaths) {
-      const subKey = sub.replace(/\\.js$/, "");
-      const shimFile = path.join(aliasPath, subKey + ".js");
-      if (fs.existsSync(shimFile)) continue;
-      fs.mkdirSync(path.dirname(shimFile), { recursive: true });
-      fs.writeFileSync(
-        shimFile,
-        "module.exports = require(" + JSON.stringify(path.join(baseDir, ".next/node_modules", target, subKey)) + ");"
-      );
-    }
   }
   if (n > 0) console.log(\`Extracted \${n} assets\`);
 }


### PR DESCRIPTION
## Summary

Versions 0.6.3–0.6.7 each tried a different flavor of \"materialize a shim package at \`.next/node_modules/<mangled>/\`\". Every variant — symlink, relative require, absolute directory path, absolute file path with main resolution — failed somewhere in bun's compiled-binary resolver, which applies quirky rules to files materialized at runtime inside a node_modules entry: symlinks aren't followed, \"./\"/\"..\" doesn't resolve, directory paths skip package.json+main, package-name walks don't traverse to the parent node_modules.

What does work consistently is bun's resolution from the chunk file itself (in \`.next/server/chunks/...\`): a plain \`require(\"sharp\")\` from that location walks up node_modules and finds the canonical package extracted by \`collectExternalModules\`. So drop the shim entirely and rewrite the chunks instead.

## What changes

- Every literal occurrence of \`\"<mangled>\"\` and \`\"<mangled>/<subpath>\"\` in server chunk text is replaced with the canonical name before embedding.
- The runtime alias-creation block and the embedded \`turbopackAliases\` map are gone.
- Subpath references like \`a.y(\"prettier-.../plugins/html\")\` become \`a.y(\"prettier/plugins/html\")\` and resolve through prettier's own \`exports\` map — which the shim approach couldn't honor without effectively cloning the canonical package.

## Test plan

- [x] All 10 tests pass (3 old shim-shape assertions replaced with rewrite assertions)
- [x] Verified end-to-end locally: chunks scrubbed of mangled names, canonical refs in their place, binary boots, lazy chunks load, \`require(\"sharp\")\` resolves cleanly all the way into sharp's own native-binding loader (which is sharp's territory from there)