### PR TITLE
Rewrite alias names in chunks for the ESM import() path

### DIFF
--- a/src/generate.test.ts
+++ b/src/generate.test.ts
@@ -326,11 +326,17 @@ describe("generateEntryPoint", () => {
 
     generateEntryPoint({ standaloneDir, distDir, projectDir });
 
-    // Chunk content is untouched — the hook handles redirection at runtime
+    // ESM `import()` doesn't go through the Module hook, so chunk text is
+    // rewritten to canonical names for the ESM resolver. The CJS hook
+    // still handles any require() that ends up mangled.
     const chunk = readFileSync(join(root, chunkPath), "utf-8");
-    expect(chunk).toBe(chunkSource);
+    expect(chunk).not.toContain("sharp-457ea9eae1af1a9c");
+    expect(chunk).not.toContain("prettier-285d8f1d6bb5f650");
+    expect(chunk).toContain('a.x("sharp"');
+    expect(chunk).toContain('require("sharp")');
+    expect(chunk).toContain('a.y("prettier/plugins/html")');
 
-    // Canonical packages still embedded so the redirected requires resolve
+    // Canonical packages embedded
     const assets = readFileSync(join(standaloneDir, "assets.generated.js"), "utf-8");
     expect(assets).toContain("sharp/index.js");
     expect(assets).toContain("prettier/plugins/html.js");

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -236,6 +236,51 @@ function findTurbopackAliases(
   }));
 }
 
+/**
+ * Rewrite every literal `"<alias>"` reference in the server chunks to the
+ * canonical name. The runtime resolver hook (see server-entry) handles
+ * the CJS path, but ESM `import()` doesn't go through Module hooks — bun's
+ * own ESM resolver runs against whatever specifier the chunk passes, and
+ * it has no knowledge of the alias→canonical mapping. Rewriting at build
+ * time ensures `import("<mangled>/sub")` becomes `import("<target>/sub")`
+ * so bun's standard ESM walk + exports-map handling can resolve it.
+ */
+function rewriteTurbopackAliases(
+  standaloneNextDir: string,
+  aliases: Array<{ alias: string; target: string }>
+): void {
+  if (aliases.length === 0) return;
+  const serverDir = join(standaloneNextDir, "server");
+  if (!existsSync(serverDir)) return;
+  const escape = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  // Match the alias name followed immediately by `/`, `"`, or `'` — guards
+  // against any longer identifier that happens to start with the alias.
+  const pattern = new RegExp(
+    "([\"'])(" + aliases.map((a) => escape(a.alias)).join("|") + ")(?=[/\"'])",
+    "g"
+  );
+  const targetByAlias = new Map(aliases.map((a) => [a.alias, a.target]));
+  let rewritten = 0;
+  for (const f of walkDir(serverDir)) {
+    if (!f.absolutePath.endsWith(".js")) continue;
+    let content: string;
+    try {
+      content = readFileSync(f.absolutePath, "utf-8");
+    } catch {
+      continue;
+    }
+    const next = content.replace(pattern, (_m, q, alias) => q + targetByAlias.get(alias)!);
+    if (next !== content) {
+      writeFileSync(f.absolutePath, next);
+      rewritten++;
+    }
+  }
+  if (rewritten > 0) {
+    console.log(
+      `next-bun-compile: Rewrote turbopack-mangled aliases in ${rewritten} server chunks`
+    );
+  }
+}
 
 /**
  * Locate the directory containing server.js inside the standalone output.
@@ -440,10 +485,13 @@ export function generateEntryPoint(options: GenerateOptions): string {
   }));
 
   // Discover turbopack mangled aliases (e.g. `sharp-457ea9eae1af1a9c`).
-  // The chunks reference them as-is; the runtime hook (see server-entry)
-  // redirects each alias to its canonical name when bun's resolver fails.
+  // For ESM `import()` calls the chunks are rewritten in place — bun's ESM
+  // resolver doesn't go through our Module hook. For CJS `require()` calls
+  // the rewrite is belt-and-suspenders; the runtime hook in server-entry
+  // also redirects aliases by name as a fallback.
   const standaloneNextDir = join(serverDir, ".next");
   const turbopackAliases = findTurbopackAliases(standaloneNextDir);
+  rewriteTurbopackAliases(standaloneNextDir, turbopackAliases);
   const aliasNames = new Set(turbopackAliases.map((a) => a.alias));
   const runtimeFiles = walkDir(standaloneNextDir)
     .filter((f) => {


### PR DESCRIPTION
## Summary

v0.6.11 dropped the build-time chunk rewrite on the assumption that the runtime \`Module._resolveFilename\` hook handled every case. Field reports show the hook only catches CJS — ESM \`import()\` bypasses Module hooks entirely. Turbopack chunks use \`await a.y(\"<mangled>/<sub>\")\` for externalImport calls, and bun's ESM resolver has no way to map mangled names back to the canonical package.

\`\`\`
Failed to load external module prettier-285d8f1d6bb5f650/plugins/html:
ResolveMessage: Cannot find module 'prettier-285d8f1d6bb5f650/plugins/html'
  from '/app/.next/server/chunks/ssr/[turbopack]_runtime.js'
    at externalImport (...)
\`\`\`

## Fix

Bring back the minimal name-substitution rewrite from v0.6.8 — every quoted \`\"<alias>\"\` reference in server chunks becomes \`\"<canonical>\"\`. Bun's ESM resolver then walks node_modules from the chunk location and resolves the canonical package through its standard \`exports\` map handling. No \`__NBC_BASE__\` placeholder machinery; the chunks just call the canonical name and bun's ESM walk (which behaves differently from its CJS walk) does the rest.

The CJS hook + alias map from v0.6.10/v0.6.11 stays as belt-and-suspenders for any require() that still ends up referencing the mangled name.

## Test plan

- [x] All 10 tests pass
- [x] Verified locally: mangled refs scrubbed from chunks, canonical refs in their place, alias map still injected for the hook fallback