### PR TITLE
Add E2E test fixture (sharp) and CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,3 +24,63 @@ jobs:
 
       - name: Test
         run: bun test
+
+  e2e-sharp:
+    name: E2E (sharp)
+    runs-on: ubuntu-latest
+    timeout-minutes: 6
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Build adapter
+        run: |
+          bun install
+          bun run build
+
+      - name: Install fixture deps
+        working-directory: test/e2e/sharp-app
+        run: bun install
+
+      - name: Compile fixture binary
+        working-directory: test/e2e/sharp-app
+        run: bun --bun run build
+
+      - name: Boot binary and verify sharp serves a PNG
+        working-directory: test/e2e/sharp-app
+        run: |
+          PORT=3001 ./server > /tmp/server.log 2>&1 &
+          SERVER_PID=$!
+
+          # Wait up to 30s for readiness
+          for i in $(seq 1 30); do
+            if curl -fsS -o /dev/null http://localhost:3001/; then
+              break
+            fi
+            sleep 1
+          done
+
+          # Hit the sharp-driven endpoint
+          HTTP_STATUS=$(curl -sS -o /tmp/out.png -w "%{http_code}" http://localhost:3001/api/resize)
+
+          kill $SERVER_PID 2>/dev/null || true
+          sleep 1
+
+          echo "--- server log ---"
+          cat /tmp/server.log
+
+          if [ "$HTTP_STATUS" != "200" ]; then
+            echo "❌ /api/resize returned $HTTP_STATUS"
+            exit 1
+          fi
+
+          if ! file /tmp/out.png | grep -q "PNG image"; then
+            echo "❌ /api/resize output is not a PNG:"
+            file /tmp/out.png
+            exit 1
+          fi
+
+          echo "✅ sharp resolved + loaded + produced a PNG end-to-end"

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -74,31 +74,67 @@ function toVarName(filePath: string): string {
  * Find all real locations of a package inside node_modules/, including
  * hoisted layouts used by bun (.bun/) and pnpm (.pnpm/).
  * Both use: node_modules/.<manager>/<pkg>@version/node_modules/<pkg>/
+ *
+ * Walks the entire standalone tree to find every `node_modules/` directory,
+ * then checks for direct + hoisted-store locations in each. Necessary for
+ * monorepo-style standalone outputs where Next.js produces both a top-level
+ * `standalone/node_modules/` AND nested copies like
+ * `standalone/<app-path>/node_modules/` — the bundler resolves the nearest
+ * one, so stubs/shims have to be placed in every location.
  */
-function findPackageDirs(
-  nodeModulesDir: string,
-  pkg: string
-): string[] {
+function findPackageDirs(standaloneDir: string, pkg: string): string[] {
   const dirs: string[] = [];
-
-  // Direct path: node_modules/<pkg>/
-  const direct = join(nodeModulesDir, pkg);
-  if (existsSync(direct)) dirs.push(direct);
-
-  // Hoisted layouts (.bun/ and .pnpm/)
   const prefix = pkg.startsWith("@")
     ? pkg.split("/")[0] + "+" + pkg.split("/")[1]
     : pkg;
-  for (const store of [".bun", ".pnpm"]) {
-    const storeDir = join(nodeModulesDir, store);
-    if (!existsSync(storeDir)) continue;
-    for (const entry of readdirSync(storeDir)) {
-      if (!entry.startsWith(prefix + "@")) continue;
-      const hoisted = join(storeDir, entry, "node_modules", pkg);
-      if (existsSync(hoisted)) dirs.push(hoisted);
-    }
-  }
+  const seen = new Set<string>();
 
+  const checkNodeModules = (nodeModulesDir: string) => {
+    // Direct: node_modules/<pkg>/
+    const direct = join(nodeModulesDir, pkg);
+    if (existsSync(direct) && !seen.has(direct)) {
+      seen.add(direct);
+      dirs.push(direct);
+    }
+    // Hoisted stores: .bun/<pkg>@<ver>/node_modules/<pkg>/ etc.
+    for (const store of [".bun", ".pnpm"]) {
+      const storeDir = join(nodeModulesDir, store);
+      if (!existsSync(storeDir)) continue;
+      let entries: string[];
+      try {
+        entries = readdirSync(storeDir);
+      } catch {
+        continue;
+      }
+      for (const entry of entries) {
+        if (!entry.startsWith(prefix + "@")) continue;
+        const hoisted = join(storeDir, entry, "node_modules", pkg);
+        if (existsSync(hoisted) && !seen.has(hoisted)) {
+          seen.add(hoisted);
+          dirs.push(hoisted);
+        }
+      }
+    }
+  };
+
+  const walk = (dir: string) => {
+    let entries: string[];
+    try {
+      entries = readdirSync(dir);
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const full = join(dir, entry);
+      if (entry === "node_modules") {
+        checkNodeModules(full);
+        continue; // don't descend into node_modules itself
+      }
+      const stat = tryStat(full);
+      if (stat && stat.isDirectory()) walk(full);
+    }
+  };
+  walk(standaloneDir);
   return dirs;
 }
 
@@ -131,7 +167,7 @@ function generateStubs(standaloneDir: string): void {
   const nodeModulesDir = join(standaloneDir, "node_modules");
   let count = 0;
   for (const stub of stubs) {
-    const pkgDirs = findPackageDirs(nodeModulesDir, stub.pkg);
+    const pkgDirs = findPackageDirs(standaloneDir, stub.pkg);
     // If the package isn't installed at all, create stub at the default location
     if (pkgDirs.length === 0) pkgDirs.push(join(nodeModulesDir, stub.pkg));
 
@@ -403,8 +439,7 @@ function findServerDir(standaloneDir: string): string {
  * there's no node_modules on disk (deployed compiled binary).
  */
 function patchRequireHook(standaloneDir: string): void {
-  const nodeModulesDir = join(standaloneDir, "node_modules");
-  const nextDirs = findPackageDirs(nodeModulesDir, "next");
+  const nextDirs = findPackageDirs(standaloneDir, "next");
 
   const target =
     "let resolve = process.env.NEXT_MINIMAL ? __non_webpack_require__.resolve : require.resolve;";
@@ -442,10 +477,12 @@ function patchRequireHook(standaloneDir: string): void {
 function collectExternalModules(
   standaloneDir: string
 ): Array<{ mod: string; src: string }> {
-  const nodeModulesDir = join(standaloneDir, "node_modules");
-  if (!existsSync(nodeModulesDir)) return [];
-
   // Collect all package directories, including those in .bun/.pnpm stores
+  // and nested node_modules anywhere in the standalone tree (monorepo
+  // layouts produce both `standalone/node_modules/` and
+  // `standalone/<app>/node_modules/`; only collecting the top-level one
+  // misses packages that are nested-only, like next.js's own runtime files
+  // when `file:` deps push the dep tree into a nested copy).
   const pkgRoots = new Map<string, string>(); // pkg name -> absolute path
 
   function addPkg(name: string, path: string) {
@@ -471,16 +508,33 @@ function collectExternalModules(
     }
   }
 
-  scanDir(nodeModulesDir);
-
-  for (const store of [".bun", ".pnpm"]) {
-    const storeDir = join(nodeModulesDir, store);
-    if (!existsSync(storeDir)) continue;
-    for (const storeEntry of readdirSync(storeDir)) {
-      const nested = join(storeDir, storeEntry, "node_modules");
-      if (existsSync(nested)) scanDir(nested);
+  // Walk the entire standalone tree and process every `node_modules/` we
+  // find (top-level, nested app dirs, etc.). Doesn't recurse into
+  // node_modules itself — the .bun/.pnpm hoisted stores are handled
+  // explicitly per node_modules.
+  function walkForNodeModules(dir: string) {
+    let entries: string[];
+    try { entries = readdirSync(dir); } catch { return; }
+    for (const entry of entries) {
+      const full = join(dir, entry);
+      if (entry === "node_modules") {
+        scanDir(full);
+        for (const store of [".bun", ".pnpm"]) {
+          const storeDir = join(full, store);
+          if (!existsSync(storeDir)) continue;
+          for (const storeEntry of readdirSync(storeDir)) {
+            const nested = join(storeDir, storeEntry, "node_modules");
+            if (existsSync(nested)) scanDir(nested);
+          }
+        }
+        continue;
+      }
+      const stat = tryStat(full);
+      if (stat && stat.isDirectory()) walkForNodeModules(full);
     }
   }
+  walkForNodeModules(standaloneDir);
+  if (pkgRoots.size === 0) return [];
 
   const results: Array<{ mod: string; src: string }> = [];
   for (const [name, pkgPath] of pkgRoots) {
@@ -500,11 +554,9 @@ function collectExternalModules(
  * or "exports" maps.
  */
 function fixModuleResolution(standaloneDir: string): void {
-  const nodeModulesDir = join(standaloneDir, "node_modules");
-
   // 1. Create index.js shims for next/dist/compiled/* packages whose
   //    package.json "main" isn't index.js (e.g. source-map -> source-map.js)
-  for (const pkgDir of findPackageDirs(nodeModulesDir, "next")) {
+  for (const pkgDir of findPackageDirs(standaloneDir, "next")) {
     const compiledDir = join(pkgDir, "dist/compiled");
     if (!existsSync(compiledDir)) continue;
     for (const entry of readdirSync(compiledDir)) {
@@ -523,7 +575,7 @@ function fixModuleResolution(standaloneDir: string): void {
 
   // 2. Create filesystem shims for packages using "exports" maps that bun's
   //    compiled binary can't resolve (e.g. @swc/helpers/_/X -> cjs/X.cjs)
-  for (const helpersDir of findPackageDirs(nodeModulesDir, "@swc/helpers")) {
+  for (const helpersDir of findPackageDirs(standaloneDir, "@swc/helpers")) {
     const cjsDir = join(helpersDir, "cjs");
     if (!existsSync(cjsDir)) continue;
     for (const file of readdirSync(cjsDir)) {

--- a/test/e2e/sharp-app/.gitignore
+++ b/test/e2e/sharp-app/.gitignore
@@ -1,0 +1,9 @@
+node_modules
+.next
+server
+bun.lock
+next-env.d.ts
+.*.bun-build
+server-entry.js
+server-entry.js.map
+assets.generated.js

--- a/test/e2e/sharp-app/app/api/resize/route.ts
+++ b/test/e2e/sharp-app/app/api/resize/route.ts
@@ -1,0 +1,30 @@
+import sharp from "sharp";
+
+/**
+ * Generates a tiny PNG via sharp so the compiled binary actually exercises
+ * the externalized-package code paths: bun chunk → externalImport/
+ * externalRequire → sharp main → sharp's internal `require('detect-libc')`
+ * and dynamic `require('@img/sharp-${platform}/sharp.node')` chain.
+ *
+ * If any layer of resolution regresses, this request fails.
+ */
+export async function GET() {
+  const buf = await sharp({
+    create: {
+      width: 32,
+      height: 32,
+      channels: 4,
+      background: { r: 255, g: 0, b: 0, alpha: 1 },
+    },
+  })
+    .png()
+    .toBuffer();
+
+  return new Response(new Uint8Array(buf), {
+    status: 200,
+    headers: {
+      "content-type": "image/png",
+      "cache-control": "no-store",
+    },
+  });
+}

--- a/test/e2e/sharp-app/app/layout.tsx
+++ b/test/e2e/sharp-app/app/layout.tsx
@@ -1,0 +1,11 @@
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/test/e2e/sharp-app/app/page.tsx
+++ b/test/e2e/sharp-app/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Home() {
+  return <main>e2e-sharp-app</main>;
+}

--- a/test/e2e/sharp-app/next.config.ts
+++ b/test/e2e/sharp-app/next.config.ts
@@ -1,0 +1,7 @@
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {
+  adapterPath: import.meta.resolve("next-bun-compile"),
+};
+
+export default nextConfig;

--- a/test/e2e/sharp-app/package.json
+++ b/test/e2e/sharp-app/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "e2e-sharp-app",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "next build && next-bun-compile"
+  },
+  "dependencies": {
+    "next": "16.2.7",
+    "react": "^19.2.0",
+    "react-dom": "^19.2.0",
+    "sharp": "^0.34.5"
+  },
+  "devDependencies": {
+    "next-bun-compile": "file:../../..",
+    "@types/node": "^22",
+    "@types/react": "^19",
+    "@types/react-dom": "^19",
+    "typescript": "^5"
+  }
+}

--- a/test/e2e/sharp-app/tsconfig.json
+++ b/test/e2e/sharp-app/tsconfig.json
@@ -1,0 +1,37 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    ".next"
+  ]
+}


### PR DESCRIPTION
## Summary

Unit tests scaffold inputs and assert on transformed outputs, but they don't compile a real binary, boot it, and exercise the externalized-package chain. That gap let v0.6.11→v0.6.12's ESM bypass slip through unit tests and only surface in deploy.

Add a minimal Next 16 fixture with a route that generates a PNG via sharp (forces the whole load chain: chunk \`externalImport\`/\`externalRequire\` → sharp main → sharp's own \`require('detect-libc')\` → dynamic \`@img/sharp-\${platform}/sharp.node\` dlopen). CI compiles the fixture, boots it, curls \`/api/resize\`, and asserts the response is a PNG. Regressions in any layer of resolver behavior fail the build instead of failing a deploy.

## What's in the diff

- \`test/e2e/sharp-app/\` — minimal Next 16 + sharp fixture
- \`.github/workflows/ci.yml\` — new \`e2e-sharp\` job
- Two library fixes surfaced while wiring this up:
  - \`findPackageDirs\` now walks the whole standalone tree, not just \`standalone/node_modules/\`. Stubs and shims land in nested-app-dir copies of \`next/\` too (relevant for monorepo-style standalone outputs).
  - \`collectExternalModules\` walks the whole tree too. Packages that exist only in a nested \`standalone/<app>/node_modules/\` are now extracted (otherwise required runtime files like \`next/dist/compiled/next-server/app-page-turbo.runtime.prod.js\` go missing).

## Test plan

- [x] All 10 unit tests pass
- [x] Fixture builds + boots + serves a valid PNG locally
- [x] The two library fixes are exercised by the fixture build (without them the build/boot fails)