### PR TITLE
Add build-time pre-flight validator for alias resolutions

### DIFF
--- a/src/generate.test.ts
+++ b/src/generate.test.ts
@@ -387,6 +387,79 @@ describe("generateEntryPoint", () => {
     expect(entry).toContain('"sharp-457ea9eae1af1a9c":"sharp"');
   });
 
+  test("validator warns when an alias references a missing canonical package", () => {
+    // Chunk references `missing-pkg-deadbeefdeadbeef` but no `missing-pkg`
+    // is installed anywhere in the standalone. The build still has to run
+    // to completion (we don't fail the build — runtime might handle it
+    // via try/catch in an optional code path) but it must emit a warning
+    // so the user sees the issue at build time, not deploy time.
+    const root = join(tmpBase, "alias-unresolved-warn");
+    const distDir = join(root, ".next");
+    const standaloneDir = join(distDir, "standalone");
+    const projectDir = root;
+
+    scaffold(root, {
+      ".next/bun-compile-ctx.json": MOCK_CTX,
+      ".next/static/app.js": "// static",
+      ".next/standalone/server.js": MOCK_SERVER_JS,
+      ".next/standalone/.next/BUILD_ID": "warn-build",
+      ".next/standalone/.next/server/chunks/ssr/page.js":
+        `require("missing-pkg-deadbeefdeadbeef")`,
+      ".next/standalone/node_modules/next/package.json": MOCK_NEXT_PKG,
+      ".next/standalone/node_modules/next/dist/server/require-hook.js": MOCK_REQUIRE_HOOK,
+      // no missing-pkg anywhere
+      "public/favicon.ico": "icon",
+    });
+
+    const warns: string[] = [];
+    const origWarn = console.warn;
+    console.warn = (...args: unknown[]) => warns.push(args.join(" "));
+    try {
+      generateEntryPoint({ standaloneDir, distDir, projectDir });
+    } finally {
+      console.warn = origWarn;
+    }
+
+    const joined = warns.join("\n");
+    expect(joined).toContain("missing-pkg-deadbeefdeadbeef");
+    expect(joined).toContain("missing-pkg");
+    expect(joined).toContain("won't resolve at runtime");
+  });
+
+  test("validator stays quiet when every alias resolves", () => {
+    const root = join(tmpBase, "alias-all-resolved");
+    const distDir = join(root, ".next");
+    const standaloneDir = join(distDir, "standalone");
+    const projectDir = root;
+
+    scaffold(root, {
+      ".next/bun-compile-ctx.json": MOCK_CTX,
+      ".next/static/app.js": "// static",
+      ".next/standalone/server.js": MOCK_SERVER_JS,
+      ".next/standalone/.next/BUILD_ID": "ok-build",
+      ".next/standalone/.next/server/chunks/ssr/page.js":
+        `require("sharp-457ea9eae1af1a9c")`,
+      ".next/standalone/node_modules/next/package.json": MOCK_NEXT_PKG,
+      ".next/standalone/node_modules/next/dist/server/require-hook.js": MOCK_REQUIRE_HOOK,
+      ".next/standalone/node_modules/.bun/sharp@0.34.5/node_modules/sharp/package.json":
+        JSON.stringify({ name: "sharp", main: "index.js" }),
+      ".next/standalone/node_modules/.bun/sharp@0.34.5/node_modules/sharp/index.js":
+        "module.exports = {};",
+      "public/favicon.ico": "icon",
+    });
+
+    const warns: string[] = [];
+    const origWarn = console.warn;
+    console.warn = (...args: unknown[]) => warns.push(args.join(" "));
+    try {
+      generateEntryPoint({ standaloneDir, distDir, projectDir });
+    } finally {
+      console.warn = origWarn;
+    }
+
+    expect(warns.join("\n")).not.toContain("won't resolve");
+  });
+
   test("deeply nested monorepo layout (packages/apps/web)", () => {
     const root = join(tmpBase, "deep-mono");
     const distDir = join(root, ".next");

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -337,6 +337,69 @@ function buildCanonicalResolutions(
 }
 
 /**
+ * Pre-flight check on alias resolutions. For every alias + subpath the
+ * chunks reference, verify that we found a concrete file to point at. If
+ * any didn't resolve, emit a loud warning at build time — the chunk will
+ * throw at runtime when the unresolved reference is hit, and surfacing
+ * it now (with the canonical name we tried to find) is much cheaper than
+ * a deploy round-trip. Returns the unresolved entries so callers/tests
+ * can act on them.
+ *
+ * Verbose mode (`NEXT_BUN_COMPILE_VERBOSE=1`) lists every alias along
+ * with the file it resolved to — useful for verifying exports-map
+ * handling picked the right variant (.mjs vs .js vs .cjs).
+ */
+function validateAliasResolutions(
+  aliases: Array<{ alias: string; target: string; subpaths: string[] }>,
+  resolutions: Map<string, string>
+): Array<{ ref: string; canonical: string }> {
+  const verbose = process.env.NEXT_BUN_COMPILE_VERBOSE === "1";
+  const all: Array<{ ref: string; canonical: string; file: string | null }> = [];
+  for (const { alias, target, subpaths } of aliases) {
+    all.push({ ref: alias, canonical: target, file: resolutions.get(alias) ?? null });
+    for (const sub of subpaths) {
+      const ref = `${alias}/${sub}`;
+      all.push({
+        ref,
+        canonical: `${target}/${sub}`,
+        file: resolutions.get(ref) ?? null,
+      });
+    }
+  }
+  const unresolved = all
+    .filter((e) => !e.file)
+    .map(({ ref, canonical }) => ({ ref, canonical }));
+
+  if (verbose && all.length > 0) {
+    console.log(
+      `next-bun-compile: Validating ${all.length} turbopack alias reference(s):`
+    );
+    for (const { ref, canonical, file } of all) {
+      if (file) {
+        const display = file.replace(/^\.next\/node_modules\//, "");
+        console.log(`  ✓ ${ref} → ${canonical} (${display})`);
+      } else {
+        console.log(`  ✗ ${ref} → ${canonical} (NOT FOUND)`);
+      }
+    }
+  }
+  if (unresolved.length > 0) {
+    console.warn(
+      `next-bun-compile: ⚠ ${unresolved.length} of ${all.length} turbopack alias reference(s) won't resolve at runtime:`
+    );
+    for (const { ref, canonical } of unresolved) {
+      console.warn(`  ✗ ${ref} → ${canonical}`);
+    }
+    console.warn(
+      `next-bun-compile: These chunks will throw at runtime when the reference is hit. ` +
+        `Either the package is missing from dependencies, or it's hidden behind a path the ` +
+        `standalone trace didn't include. Try adding to transpilePackages in next.config.`
+    );
+  }
+  return unresolved;
+}
+
+/**
  * Replace every literal `"<alias>"` or `"<alias>/<sub>"` in the server
  * chunks with the absolute file path of the canonical target, anchored on
  * a `__NBC_BASE__` placeholder that's substituted with the real baseDir
@@ -659,10 +722,13 @@ export function generateEntryPoint(options: GenerateOptions): string {
   // package.json for top-level, the right extension for each subpath),
   // then rewrite chunk references to absolute file paths via the
   // __NBC_BASE__ placeholder. Substituted with baseDir at extract time.
+  // validateAliasResolutions warns about any that didn't resolve before
+  // we get to runtime — much cheaper than a deploy round-trip.
   const canonicalResolutions = buildCanonicalResolutions(
     externalDir,
     turbopackAliases
   );
+  validateAliasResolutions(turbopackAliases, canonicalResolutions);
   rewriteTurbopackAliases(standaloneNextDir, turbopackAliases, canonicalResolutions);
 
   // Check build context for assetPrefix — if set, static assets are served


### PR DESCRIPTION
## Summary

When \`buildCanonicalResolutions\` can't find a concrete file for an alias or subpath reference, the rewrite skips it and the chunk keeps the mangled name — which throws at runtime when the reference is hit. The user only finds out after deploying.

Validate at build time instead. For every alias + subpath the chunks reference, check whether resolution found a file. If any didn't, print a loud warning with the canonical name we tried to find:

\`\`\`
next-bun-compile: ⚠ 1 of 4 turbopack alias reference(s) won't resolve at runtime:
  ✗ some-pkg-deadbeef/foo → some-pkg/foo
next-bun-compile: These chunks will throw at runtime when the reference is hit.
\`\`\`

\`NEXT_BUN_COMPILE_VERBOSE=1\` also lists every successful resolution with the file it picked — useful for verifying exports-map handling chose the right variant (.mjs vs .js vs .cjs):

\`\`\`
next-bun-compile: Validating 1 turbopack alias reference(s):
  ✓ sharp-91413508168e89eb → sharp (sharp/lib/index.js)
\`\`\`

## Notes

- Doesn't fail the build. Some references may be in optional code paths that never fire at runtime — the warning is enough.
- Quiet by default when everything resolves; no noise in the common case.

## Test plan

- [x] 12/12 unit tests pass (2 new: missing-package warns, all-resolved stays quiet)
- [x] Smoke-tested both quiet and verbose modes against the e2e fixture