### PR TITLE
Add NEXT_BUN_COMPILE_DEBUG=1 resolver hook logging

### DIFF
--- a/src/generate.test.ts
+++ b/src/generate.test.ts
@@ -426,6 +426,36 @@ describe("generateEntryPoint", () => {
     expect(joined).toContain("won't resolve at runtime");
   });
 
+  test("server-entry embeds the debug-mode resolver hook logging", () => {
+    // Debug mode is gated by NEXT_BUN_COMPILE_DEBUG at runtime — the
+    // emitted entry just needs to contain the conditional + log calls
+    // so users can flip the env var without rebuilding.
+    const root = join(tmpBase, "debug-mode-emitted");
+    const distDir = join(root, ".next");
+    const standaloneDir = join(distDir, "standalone");
+    const projectDir = root;
+
+    scaffold(root, {
+      ".next/bun-compile-ctx.json": MOCK_CTX,
+      ".next/static/app.js": "// static",
+      ".next/standalone/server.js": MOCK_SERVER_JS,
+      ".next/standalone/.next/BUILD_ID": "debug-build",
+      ".next/standalone/.next/server/chunks/ssr/page.js": `// chunk`,
+      ".next/standalone/node_modules/next/package.json": MOCK_NEXT_PKG,
+      ".next/standalone/node_modules/next/dist/server/require-hook.js": MOCK_REQUIRE_HOOK,
+      "public/favicon.ico": "icon",
+    });
+
+    generateEntryPoint({ standaloneDir, distDir, projectDir });
+    const entry = readFileSync(join(standaloneDir, "server-entry.js"), "utf-8");
+
+    expect(entry).toContain("NEXT_BUN_COMPILE_DEBUG");
+    expect(entry).toContain("__nbcDebug");
+    expect(entry).toContain("redirected");
+    expect(entry).toContain("fallback resolved");
+    expect(entry).toContain("fallback FAILED");
+  });
+
   test("validator stays quiet when every alias resolves", () => {
     const root = join(tmpBase, "alias-all-resolved");
     const distDir = join(root, ".next");

--- a/src/generate.test.ts
+++ b/src/generate.test.ts
@@ -387,6 +387,79 @@ describe("generateEntryPoint", () => {
     expect(entry).toContain('"sharp-457ea9eae1af1a9c":"sharp"');
   });
 
+  test("validator warns when an alias references a missing canonical package", () => {
+    // Chunk references `missing-pkg-deadbeefdeadbeef` but no `missing-pkg`
+    // is installed anywhere in the standalone. The build still has to run
+    // to completion (we don't fail the build — runtime might handle it
+    // via try/catch in an optional code path) but it must emit a warning
+    // so the user sees the issue at build time, not deploy time.
+    const root = join(tmpBase, "alias-unresolved-warn");
+    const distDir = join(root, ".next");
+    const standaloneDir = join(distDir, "standalone");
+    const projectDir = root;
+
+    scaffold(root, {
+      ".next/bun-compile-ctx.json": MOCK_CTX,
+      ".next/static/app.js": "// static",
+      ".next/standalone/server.js": MOCK_SERVER_JS,
+      ".next/standalone/.next/BUILD_ID": "warn-build",
+      ".next/standalone/.next/server/chunks/ssr/page.js":
+        `require("missing-pkg-deadbeefdeadbeef")`,
+      ".next/standalone/node_modules/next/package.json": MOCK_NEXT_PKG,
+      ".next/standalone/node_modules/next/dist/server/require-hook.js": MOCK_REQUIRE_HOOK,
+      // no missing-pkg anywhere
+      "public/favicon.ico": "icon",
+    });
+
+    const warns: string[] = [];
+    const origWarn = console.warn;
+    console.warn = (...args: unknown[]) => warns.push(args.join(" "));
+    try {
+      generateEntryPoint({ standaloneDir, distDir, projectDir });
+    } finally {
+      console.warn = origWarn;
+    }
+
+    const joined = warns.join("\n");
+    expect(joined).toContain("missing-pkg-deadbeefdeadbeef");
+    expect(joined).toContain("missing-pkg");
+    expect(joined).toContain("won't resolve at runtime");
+  });
+
+  test("validator stays quiet when every alias resolves", () => {
+    const root = join(tmpBase, "alias-all-resolved");
+    const distDir = join(root, ".next");
+    const standaloneDir = join(distDir, "standalone");
+    const projectDir = root;
+
+    scaffold(root, {
+      ".next/bun-compile-ctx.json": MOCK_CTX,
+      ".next/static/app.js": "// static",
+      ".next/standalone/server.js": MOCK_SERVER_JS,
+      ".next/standalone/.next/BUILD_ID": "ok-build",
+      ".next/standalone/.next/server/chunks/ssr/page.js":
+        `require("sharp-457ea9eae1af1a9c")`,
+      ".next/standalone/node_modules/next/package.json": MOCK_NEXT_PKG,
+      ".next/standalone/node_modules/next/dist/server/require-hook.js": MOCK_REQUIRE_HOOK,
+      ".next/standalone/node_modules/.bun/sharp@0.34.5/node_modules/sharp/package.json":
+        JSON.stringify({ name: "sharp", main: "index.js" }),
+      ".next/standalone/node_modules/.bun/sharp@0.34.5/node_modules/sharp/index.js":
+        "module.exports = {};",
+      "public/favicon.ico": "icon",
+    });
+
+    const warns: string[] = [];
+    const origWarn = console.warn;
+    console.warn = (...args: unknown[]) => warns.push(args.join(" "));
+    try {
+      generateEntryPoint({ standaloneDir, distDir, projectDir });
+    } finally {
+      console.warn = origWarn;
+    }
+
+    expect(warns.join("\n")).not.toContain("won't resolve");
+  });
+
   test("deeply nested monorepo layout (packages/apps/web)", () => {
     const root = join(tmpBase, "deep-mono");
     const distDir = join(root, ".next");

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -337,6 +337,69 @@ function buildCanonicalResolutions(
 }
 
 /**
+ * Pre-flight check on alias resolutions. For every alias + subpath the
+ * chunks reference, verify that we found a concrete file to point at. If
+ * any didn't resolve, emit a loud warning at build time — the chunk will
+ * throw at runtime when the unresolved reference is hit, and surfacing
+ * it now (with the canonical name we tried to find) is much cheaper than
+ * a deploy round-trip. Returns the unresolved entries so callers/tests
+ * can act on them.
+ *
+ * Verbose mode (`NEXT_BUN_COMPILE_VERBOSE=1`) lists every alias along
+ * with the file it resolved to — useful for verifying exports-map
+ * handling picked the right variant (.mjs vs .js vs .cjs).
+ */
+function validateAliasResolutions(
+  aliases: Array<{ alias: string; target: string; subpaths: string[] }>,
+  resolutions: Map<string, string>
+): Array<{ ref: string; canonical: string }> {
+  const verbose = process.env.NEXT_BUN_COMPILE_VERBOSE === "1";
+  const all: Array<{ ref: string; canonical: string; file: string | null }> = [];
+  for (const { alias, target, subpaths } of aliases) {
+    all.push({ ref: alias, canonical: target, file: resolutions.get(alias) ?? null });
+    for (const sub of subpaths) {
+      const ref = `${alias}/${sub}`;
+      all.push({
+        ref,
+        canonical: `${target}/${sub}`,
+        file: resolutions.get(ref) ?? null,
+      });
+    }
+  }
+  const unresolved = all
+    .filter((e) => !e.file)
+    .map(({ ref, canonical }) => ({ ref, canonical }));
+
+  if (verbose && all.length > 0) {
+    console.log(
+      `next-bun-compile: Validating ${all.length} turbopack alias reference(s):`
+    );
+    for (const { ref, canonical, file } of all) {
+      if (file) {
+        const display = file.replace(/^\.next\/node_modules\//, "");
+        console.log(`  ✓ ${ref} → ${canonical} (${display})`);
+      } else {
+        console.log(`  ✗ ${ref} → ${canonical} (NOT FOUND)`);
+      }
+    }
+  }
+  if (unresolved.length > 0) {
+    console.warn(
+      `next-bun-compile: ⚠ ${unresolved.length} of ${all.length} turbopack alias reference(s) won't resolve at runtime:`
+    );
+    for (const { ref, canonical } of unresolved) {
+      console.warn(`  ✗ ${ref} → ${canonical}`);
+    }
+    console.warn(
+      `next-bun-compile: These chunks will throw at runtime when the reference is hit. ` +
+        `Either the package is missing from dependencies, or it's hidden behind a path the ` +
+        `standalone trace didn't include. Try adding to transpilePackages in next.config.`
+    );
+  }
+  return unresolved;
+}
+
+/**
  * Replace every literal `"<alias>"` or `"<alias>/<sub>"` in the server
  * chunks with the absolute file path of the canonical target, anchored on
  * a `__NBC_BASE__` placeholder that's substituted with the real baseDir
@@ -659,10 +722,13 @@ export function generateEntryPoint(options: GenerateOptions): string {
   // package.json for top-level, the right extension for each subpath),
   // then rewrite chunk references to absolute file paths via the
   // __NBC_BASE__ placeholder. Substituted with baseDir at extract time.
+  // validateAliasResolutions warns about any that didn't resolve before
+  // we get to runtime — much cheaper than a deploy round-trip.
   const canonicalResolutions = buildCanonicalResolutions(
     externalDir,
     turbopackAliases
   );
+  validateAliasResolutions(turbopackAliases, canonicalResolutions);
   rewriteTurbopackAliases(standaloneNextDir, turbopackAliases, canonicalResolutions);
 
   // Check build context for assetPrefix — if set, static assets are served

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -825,6 +825,20 @@ process.env.NODE_ENV = "production";
 const __nbcAliases = ${JSON.stringify(
     Object.fromEntries(turbopackAliases.map((a) => [a.alias, a.target]))
   )};
+// Debug mode: set NEXT_BUN_COMPILE_DEBUG=1 to log every resolver-hook
+// decision (alias redirects, fallback walks, fallback failures). Off by
+// default so production logs stay clean; turn it on when reproducing a
+// resolution bug — that one log line is usually enough to know which
+// package was missing and where the walk gave up.
+const __nbcDebug = process.env.NEXT_BUN_COMPILE_DEBUG === "1";
+function __nbcLog(msg) { console.log("next-bun-compile [debug]:", msg); }
+if (__nbcDebug) {
+  const n = Object.keys(__nbcAliases).length;
+  __nbcLog(\`resolver hook installed; \${n} alias mapping(s):\`);
+  for (const [k, v] of Object.entries(__nbcAliases)) {
+    __nbcLog(\`  \${k} → \${v}\`);
+  }
+}
 const __nbcOrigResolveFilename = Module._resolveFilename;
 function __nbcStatFile(p) {
   try { return fs.statSync(p).isFile() ? p : null; } catch { return null; }
@@ -910,6 +924,10 @@ function __nbcRedirectAlias(request) {
 }
 Module._resolveFilename = function(request, parent, isMain, options) {
   const redirected = __nbcRedirectAlias(request);
+  if (__nbcDebug && redirected !== request) {
+    const from = parent && parent.filename ? parent.filename : "<unknown>";
+    __nbcLog(\`redirected "\${request}" → "\${redirected}" (from \${from})\`);
+  }
   try {
     return __nbcOrigResolveFilename.call(this, redirected, parent, isMain, options);
   } catch (err) {
@@ -919,7 +937,15 @@ Module._resolveFilename = function(request, parent, isMain, options) {
     }
     const fromDir = parent && parent.filename ? path.dirname(parent.filename) : process.cwd();
     const resolved = __nbcResolvePackage(redirected, fromDir);
-    if (resolved) return resolved;
+    if (resolved) {
+      if (__nbcDebug) {
+        __nbcLog(\`fallback resolved "\${redirected}" → \${resolved} (from \${fromDir})\`);
+      }
+      return resolved;
+    }
+    if (__nbcDebug) {
+      __nbcLog(\`fallback FAILED for "\${redirected}" (from \${fromDir}); throwing original ResolveMessage\`);
+    }
     throw err;
   }
 };


### PR DESCRIPTION
## Summary

When a binary built with next-bun-compile fails at runtime, the bug-report → diagnosis cycle is "share the error, then 20 questions about node_modules layout, then maybe `kubectl debug`." With \`NEXT_BUN_COMPILE_DEBUG=1\`, every resolver-hook decision is logged with enough context to skip straight to the answer.

Sample output from the e2e fixture:

\`\`\`
next-bun-compile [debug]: resolver hook installed; 1 alias mapping(s):
next-bun-compile [debug]:   sharp-91413508168e89eb → sharp
next-bun-compile [debug]: fallback resolved "detect-libc" → /app/.next/node_modules/detect-libc/lib/detect-libc.js (from /app/.next/node_modules/sharp/lib)
next-bun-compile [debug]: fallback resolved "@img/sharp-linux-x64/sharp.node" → /app/.next/node_modules/@img/sharp-linux-x64/lib/sharp-linux-x64.node (from .../sharp/lib)
next-bun-compile [debug]: fallback FAILED for "missing-pkg" (from /app/...); throwing original ResolveMessage
\`\`\`

## What's logged

- **Init**: the alias→canonical map the hook will use
- **Redirect**: alias map rewrote the request
- **Fallback success**: bun's resolver failed, our Node-compatible walk succeeded
- **Fallback failure**: both bun's and our walk failed; we re-throw bun's original \`ResolveMessage\`

## Notes

- Off by default — no noise in production logs
- Each line includes the parent file path so you can trace which extracted package's internal require fired
- No rebuild needed to toggle — it's a runtime env var check

## Test plan

- [x] 13/13 unit tests pass (one new asserts the conditional + log calls are emitted into server-entry)
- [x] Smoke-tested against the e2e fixture; output shown above