### PR TITLE
Add Starlight docs site + GitHub Pages deploy

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,47 @@
+name: Deploy docs to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+    paths: [docs/**]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+        working-directory: docs
+
+      - name: Build
+        run: bun run build
+        working-directory: docs
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ One command. One binary. No runtime dependencies.
 next build  # → ./server (single executable with embedded assets)
 ```
 
+**📖 Docs: [ramonmalcolm10.github.io/next-bun-compile](https://ramonmalcolm10.github.io/next-bun-compile/)**
+
 ## Requirements
 
 - [Bun](https://bun.sh) >= 1.3

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+.astro
+bun.lock

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -1,0 +1,47 @@
+import { defineConfig } from "astro/config";
+import starlight from "@astrojs/starlight";
+
+export default defineConfig({
+  site: "https://ramonmalcolm10.github.io",
+  base: "/next-bun-compile",
+  integrations: [
+    starlight({
+      title: "next-bun-compile",
+      description:
+        "Compile Next.js apps into single-file Bun executables. One command. One binary. No runtime dependencies.",
+      social: [
+        {
+          icon: "github",
+          label: "GitHub",
+          href: "https://github.com/ramonmalcolm10/next-bun-compile",
+        },
+      ],
+      components: {
+        SocialIcons: "./src/components/SocialIcons.astro",
+      },
+      editLink: {
+        baseUrl:
+          "https://github.com/ramonmalcolm10/next-bun-compile/edit/main/docs/",
+      },
+      sidebar: [
+        {
+          label: "Start Here",
+          items: [
+            { slug: "getting-started" },
+            { slug: "configuration" },
+            { slug: "how-it-works" },
+            { slug: "troubleshooting" },
+          ],
+        },
+        {
+          label: "Guides",
+          items: [{ autogenerate: { directory: "guides" } }],
+        },
+        {
+          label: "Recipes",
+          items: [{ autogenerate: { directory: "recipes" } }],
+        },
+      ],
+    }),
+  ],
+});

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "next-bun-compile-docs",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "astro dev",
+    "build": "astro build",
+    "preview": "astro preview"
+  },
+  "dependencies": {
+    "@astrojs/starlight": "^0.40.0",
+    "astro": "^6.4.6",
+    "sharp": "^0.34.5"
+  }
+}

--- a/docs/src/components/SocialIcons.astro
+++ b/docs/src/components/SocialIcons.astro
@@ -1,0 +1,32 @@
+---
+import config from "virtual:starlight/user-config";
+import Icon from "../../node_modules/@astrojs/starlight/user-components/Icon.astro";
+
+const links = config.social || [];
+---
+
+{
+  links.length > 0 && (
+    <>
+      {links.map(({ label, href, icon }) => (
+        <a {href} rel="noopener" target="_blank" class="sl-flex">
+          <span class="sr-only">{label}</span>
+          <Icon name={icon} />
+        </a>
+      ))}
+    </>
+  )
+}
+
+<style>
+  @layer starlight.core {
+    a {
+      color: var(--sl-color-text-accent);
+      padding: 0.5em;
+      margin: -0.5em;
+    }
+    a:hover {
+      opacity: 0.66;
+    }
+  }
+</style>

--- a/docs/src/content.config.ts
+++ b/docs/src/content.config.ts
@@ -1,0 +1,10 @@
+import { defineCollection } from "astro:content";
+import { docsLoader } from "@astrojs/starlight/loaders";
+import { docsSchema } from "@astrojs/starlight/schema";
+
+export const collections = {
+  docs: defineCollection({
+    loader: docsLoader(),
+    schema: docsSchema(),
+  }),
+};

--- a/docs/src/content/docs/configuration.mdx
+++ b/docs/src/content/docs/configuration.mdx
@@ -1,0 +1,90 @@
+---
+title: Configuration
+description: Environment variables, CLI flags, and Next.js config options that affect next-bun-compile.
+---
+
+## Environment variables (runtime)
+
+| Variable                   | Default     | Description                                                       |
+| -------------------------- | ----------- | ----------------------------------------------------------------- |
+| `PORT`                     | `3000`      | Server port                                                       |
+| `HOSTNAME`                 | `0.0.0.0`   | Server hostname                                                   |
+| `KEEP_ALIVE_TIMEOUT`       | —           | HTTP keep-alive timeout (ms)                                      |
+| `NEXT_BUN_COMPILE_DEBUG`   | `0`         | Set to `1` to log every resolver-hook decision. See [Debug mode](/next-bun-compile/guides/debug-mode/). |
+| `NEXT_BUN_COMPILE_VERBOSE` | `0`         | Set to `1` to print the alias-resolution table at **build** time. |
+
+## CLI flags
+
+Any flags passed to `next-bun-compile` are forwarded to
+`bun build --compile`. The most useful is `--target` for
+cross-compilation:
+
+```bash
+next-bun-compile --target=bun-linux-x64
+next-bun-compile --target=bun-linux-arm64
+next-bun-compile --target=bun-windows-x64
+```
+
+See the [Cross-compilation guide](/next-bun-compile/guides/cross-compilation/)
+for the full target list.
+
+## `next.config.ts` options
+
+### `adapterPath` (required)
+
+```ts
+const nextConfig: NextConfig = {
+  adapterPath: import.meta.resolve("next-bun-compile"),
+};
+```
+
+Registers next-bun-compile as the build adapter. The adapter writes a
+build-context file that the `next-bun-compile` CLI consumes after
+`next build`.
+
+For Next.js 16.1, this lives under `experimental.adapterPath`. For
+16.2+, it's at the top level.
+
+### `assetPrefix` (optional, optimizes binary size)
+
+If you set `assetPrefix` for a CDN, the adapter detects it and
+**skips embedding static assets** in the binary — your CDN serves
+them instead. Only `public/` files and runtime chunks get embedded.
+
+```ts
+const nextConfig: NextConfig = {
+  assetPrefix: "https://cdn.example.com",
+  adapterPath: import.meta.resolve("next-bun-compile"),
+};
+```
+
+You'll need to upload `.next/static/` to your CDN separately.
+
+### `transpilePackages` (optional, for packages with dynamic requires)
+
+Some packages use dynamic `require()` calls internally that Turbopack
+can't resolve at build time. Force them through the bundler instead:
+
+```ts
+const nextConfig: NextConfig = {
+  transpilePackages: ["pino", "pino-pretty"],
+  adapterPath: import.meta.resolve("next-bun-compile"),
+};
+```
+
+See the [transpilePackages guide](/next-bun-compile/guides/transpile-packages/)
+for when you need this.
+
+## What the adapter sets automatically
+
+You **don't** need to set these — the adapter applies them in
+`modifyConfig`:
+
+- `output: "standalone"` — required for the build to produce the tree
+  next-bun-compile reads.
+
+## Where the binary appears
+
+`./server` next to the `package.json` of the project being built.
+In a monorepo, this is `apps/<your-app>/server`. The adapter detects
+monorepo layouts automatically.

--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -1,0 +1,131 @@
+---
+title: Getting Started
+description: Install next-bun-compile and ship your first Next.js binary in minutes.
+---
+
+import { Steps, Tabs, TabItem } from "@astrojs/starlight/components";
+
+## Requirements
+
+- [Bun](https://bun.sh) >= 1.3
+- [Next.js](https://nextjs.org) >= 16.0.0
+
+## Setup
+
+<Steps>
+
+1. ### Install
+
+   <Tabs>
+     <TabItem label="bun">
+       ```bash
+       bun add -D next-bun-compile
+       ```
+     </TabItem>
+     <TabItem label="npm">
+       ```bash
+       npm install -D next-bun-compile
+       ```
+     </TabItem>
+     <TabItem label="pnpm">
+       ```bash
+       pnpm add -D next-bun-compile
+       ```
+     </TabItem>
+     <TabItem label="yarn">
+       ```bash
+       yarn add -D next-bun-compile
+       ```
+     </TabItem>
+   </Tabs>
+
+2. ### Register the adapter
+
+   Add `adapterPath` to your `next.config.ts`:
+
+   ```ts
+   import type { NextConfig } from "next";
+
+   const nextConfig: NextConfig = {
+     adapterPath: import.meta.resolve("next-bun-compile"),
+   };
+
+   export default nextConfig;
+   ```
+
+   :::note[Using Next.js 16.1?]
+   Wrap it in `experimental`:
+
+   ```ts
+   const nextConfig: NextConfig = {
+     experimental: {
+       adapterPath: import.meta.resolve("next-bun-compile"),
+     },
+   };
+   ```
+   :::
+
+3. ### Update your build script
+
+   ```json
+   {
+     "scripts": {
+       "build": "next build && next-bun-compile"
+     }
+   }
+   ```
+
+   The adapter sets `output: "standalone"` automatically — you don't
+   need to add it yourself.
+
+4. ### Build the binary
+
+   ```bash
+   bun run build
+   ```
+
+   Produces a single `./server` executable next to your `package.json`.
+
+5. ### Run it
+
+   ```bash
+   ./server
+   ```
+
+   Listens on port 3000 by default. Configurable via the `PORT` env var.
+
+</Steps>
+
+## What's in the binary?
+
+- Your Next.js server runtime (chunks, manifests, build ID)
+- Static assets (`.next/static/*`)
+- Public files (`public/*`)
+- All externalized server packages (sharp, prisma, anything in
+  `serverExternalPackages`, etc.)
+- The bun runtime itself (you don't need bun on the deploy target)
+
+The binary extracts its embedded assets to disk on first run, then
+boots Next.js. Subsequent runs are instant — extraction is idempotent.
+
+## Verify it works
+
+```bash
+PORT=3000 ./server &
+curl http://localhost:3000/
+```
+
+You should see your homepage HTML. From here, the typical next step
+is putting it in a Docker image — see the
+[Distroless + sharp recipe](/next-bun-compile/recipes/distroless-sharp/)
+for a complete working Dockerfile.
+
+## Next steps
+
+- **Native deps** like `sharp` need a runner image with the right C
+  libraries. See [Native dependencies in Docker](/next-bun-compile/recipes/distroless-sharp/).
+- **Monorepos** are supported out of the box. See the
+  [Monorepo guide](/next-bun-compile/guides/monorepo/).
+- **Something went wrong?** Check [Troubleshooting](/next-bun-compile/troubleshooting/).
+- **Curious how the binary actually works?** See
+  [How it works](/next-bun-compile/how-it-works/).

--- a/docs/src/content/docs/guides/cross-compilation.mdx
+++ b/docs/src/content/docs/guides/cross-compilation.mdx
@@ -1,0 +1,71 @@
+---
+title: Cross-Compilation
+description: Build binaries for a different platform than your build machine.
+---
+
+import { Tabs, TabItem } from "@astrojs/starlight/components";
+
+Any flags passed to `next-bun-compile` are forwarded to
+`bun build --compile`. The most useful is `--target`:
+
+<Tabs>
+  <TabItem label="Linux x86_64">
+    ```bash
+    next-bun-compile --target=bun-linux-x64
+    ```
+  </TabItem>
+  <TabItem label="Linux ARM64">
+    ```bash
+    next-bun-compile --target=bun-linux-arm64
+    ```
+  </TabItem>
+  <TabItem label="macOS Apple Silicon">
+    ```bash
+    next-bun-compile --target=bun-darwin-arm64
+    ```
+  </TabItem>
+  <TabItem label="macOS Intel">
+    ```bash
+    next-bun-compile --target=bun-darwin-x64
+    ```
+  </TabItem>
+  <TabItem label="Windows">
+    ```bash
+    next-bun-compile --target=bun-windows-x64
+    ```
+  </TabItem>
+</Tabs>
+
+You can wire this into the build script:
+
+```json
+{
+  "scripts": {
+    "build:linux": "next build && next-bun-compile --target=bun-linux-x64",
+    "build:mac": "next build && next-bun-compile --target=bun-darwin-arm64"
+  }
+}
+```
+
+See the [Bun cross-compilation docs](https://bun.sh/docs/bundler/executables#cross-compile)
+for the complete target list and caveats.
+
+## Native dependencies + cross-compile
+
+If your app uses native deps like `sharp`, the binary embeds the
+native bindings that were installed for your **build platform**.
+Cross-compiling to a different OS/arch without re-installing the
+deps for that platform means those bindings won't load at runtime.
+
+**The reliable approach.** Build inside a container matching your
+deploy platform:
+
+```bash
+docker run --rm -v "$PWD":/app -w /app oven/bun:1.3.14 bash -c "
+  bun install &&
+  bun run build
+"
+```
+
+Or build in CI on a Linux runner if you're deploying to Linux —
+that's what most setups end up doing.

--- a/docs/src/content/docs/guides/debug-mode.mdx
+++ b/docs/src/content/docs/guides/debug-mode.mdx
@@ -1,0 +1,68 @@
+---
+title: Debug Mode
+description: Surface every resolver-hook decision at runtime to diagnose why a require failed.
+---
+
+When a binary fails at runtime, the bug-report → diagnosis cycle is
+usually "share the error, then 20 questions about node_modules
+layout." Debug mode flips one env var and you get the full picture.
+
+## Enable
+
+```bash
+NEXT_BUN_COMPILE_DEBUG=1 ./server
+```
+
+## What you'll see
+
+```
+next-bun-compile [debug]: resolver hook installed; 1 alias mapping(s):
+next-bun-compile [debug]:   sharp-91413508168e89eb → sharp
+next-bun-compile [debug]: fallback resolved "detect-libc" → /app/.next/node_modules/detect-libc/lib/detect-libc.js (from /app/.next/node_modules/sharp/lib)
+next-bun-compile [debug]: fallback resolved "@img/sharp-linux-x64/sharp.node" → /app/.next/node_modules/@img/sharp-linux-x64/lib/sharp-linux-x64.node (from .../sharp/lib)
+next-bun-compile [debug]: fallback FAILED for "missing-pkg" (from /app/...); throwing original ResolveMessage
+```
+
+## What each line means
+
+| Line                      | What happened                                                                       |
+| ------------------------- | ----------------------------------------------------------------------------------- |
+| `resolver hook installed` | One-shot at boot. Shows the alias-redirect table the hook will consult.             |
+| `redirected "X" → "Y"`    | Alias map rewrote a mangled name to its canonical form before resolution ran.       |
+| `fallback resolved`       | Bun's compiled-binary resolver failed; our Node-compatible walk found the file.     |
+| `fallback FAILED`         | Both bun's resolver AND our fallback walk failed. The original `ResolveMessage` will throw next. |
+
+The parent file path on each line tells you **which extracted package** triggered the require — usually enough to skip straight to the fix.
+
+## Build-time verbose mode (related)
+
+For build-time issues (an alias the build couldn't resolve to a
+concrete file), use `NEXT_BUN_COMPILE_VERBOSE=1`:
+
+```bash
+NEXT_BUN_COMPILE_VERBOSE=1 bun run build
+```
+
+Output:
+
+```
+next-bun-compile: Validating 2 turbopack alias reference(s):
+  ✓ sharp-91413508168e89eb → sharp (sharp/lib/index.js)
+  ✓ prettier-285d8f1d6bb5f650/plugins/html → prettier/plugins/html (prettier/plugins/html.mjs)
+```
+
+A `✗` line means the canonical file isn't where the adapter looked.
+Cross-reference with the verbose log if the runtime debug mode shows
+a "FAILED" for the same alias.
+
+## When to leave debug mode on
+
+Off in production. The hook itself runs on every `require()` (CJS),
+and while it short-circuits to bun's resolver in the common case
+(O(1) alias-map check, single bun.resolver call), the logging adds
+console.log overhead per resolution. Fine for debugging, not for
+hot paths.
+
+If you want **always-on** observability for the hook firing rate,
+let us know — we can add a "summary at exit" counter without
+per-call logging.

--- a/docs/src/content/docs/guides/docker.mdx
+++ b/docs/src/content/docs/guides/docker.mdx
@@ -1,0 +1,88 @@
+---
+title: Docker
+description: How to package the compiled binary into a Docker image, with notes on base image choice and native dep support.
+---
+
+## Minimal: distroless without native deps
+
+If your app doesn't use native modules, the smallest viable image is
+`gcr.io/distroless/base-debian12:nonroot` — has glibc and not much
+else, ~25MB.
+
+```dockerfile
+FROM oven/bun:1.3.14 AS builder
+WORKDIR /app
+COPY package.json bun.lock* ./
+RUN bun install --no-save
+COPY . .
+RUN bun --bun run build
+
+FROM gcr.io/distroless/base-debian12:nonroot AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+ENV HOSTNAME="0.0.0.0"
+COPY --from=builder --chown=nonroot:nonroot /app/server ./
+EXPOSE 3000
+CMD ["./server"]
+```
+
+## With native deps (sharp, bcrypt, etc.)
+
+Native modules need a `libstdc++` in the runner. Switch to
+`gcr.io/distroless/cc-debian12:nonroot` — same minimal style, but
+has `libstdc++` and `libgcc`:
+
+```dockerfile
+FROM gcr.io/distroless/cc-debian12:nonroot AS runner
+```
+
+For the full recipe (including fontconfig for libvips text
+rendering with sharp), see
+[Distroless + sharp](/next-bun-compile/recipes/distroless-sharp/).
+
+## Choosing a base image
+
+| Base image                                         | Size      | Has         | Use when                                                   |
+| -------------------------------------------------- | --------- | ----------- | ---------------------------------------------------------- |
+| `gcr.io/distroless/base-debian12:nonroot`          | ~25MB     | glibc, openssl | Pure-JS app, no native modules                          |
+| `gcr.io/distroless/cc-debian12:nonroot`            | ~30MB     | `cc` deps + libstdc++, libgcc | Any native dep (sharp, bcrypt, native query engines) |
+| `debian:12-slim`                                   | ~75MB     | full slim debian | Need apt-get for extra libs at runtime                |
+| `oven/bun:1.3.14-slim`                             | ~150MB    | bun runtime  | Skip the binary entirely; run with `bun --bun ./standalone/server.js` |
+
+## Multi-arch builds in CI
+
+GitHub Actions example for building both amd64 and arm64:
+
+```yaml
+- run: bun --bun run build --target=bun-linux-x64
+- run: mv server server-amd64
+- run: bun --bun run build --target=bun-linux-arm64
+- run: mv server server-arm64
+- uses: docker/buildx-action@v3
+- run: |
+    docker buildx build --platform linux/amd64,linux/arm64 \
+      --build-arg BINARY_AMD64=server-amd64 \
+      --build-arg BINARY_ARM64=server-arm64 \
+      -t myapp:latest --push .
+```
+
+The cross-compilation flags are documented in
+[Cross-compilation](/next-bun-compile/guides/cross-compilation/).
+
+## Why not just use `bun --bun ./server.js` instead?
+
+The standalone-with-bun-runtime path is a perfectly valid alternative
+to compiling a binary. Bigger image, simpler debug story, no
+compiled-binary resolver quirks.
+
+Use the binary when:
+
+- Image size matters (~30MB vs ~150MB)
+- Cold start matters (bytecode-precompiled boot is ~2x faster)
+- You want a single self-contained artifact
+
+Use bun + standalone when:
+
+- You want zero next-bun-compile-specific behavior
+- You're hitting edge cases the resolver hook doesn't handle
+  (please file an issue!)

--- a/docs/src/content/docs/guides/monorepo.mdx
+++ b/docs/src/content/docs/guides/monorepo.mdx
@@ -1,0 +1,88 @@
+---
+title: Monorepos
+description: bun workspaces, pnpm workspaces, and Turborepo all work — here's what to know.
+---
+
+next-bun-compile detects monorepo standalone layouts automatically.
+Next.js produces something like `apps/web/.next/standalone/apps/web/server.js`
+in a monorepo (the app path is preserved inside the standalone tree),
+and the adapter handles that without configuration.
+
+## Bun workspaces
+
+Standard bun workspaces setup, no special config:
+
+```json
+// package.json (monorepo root)
+{
+  "private": true,
+  "workspaces": ["apps/*", "packages/*"]
+}
+```
+
+```json
+// apps/web/package.json
+{
+  "name": "web",
+  "scripts": {
+    "build": "next build && next-bun-compile"
+  },
+  "dependencies": {
+    "@example/shared": "*",
+    "next": "^16",
+    "next-bun-compile": "^0.6"
+  }
+}
+```
+
+```bash
+bun install                                  # at the monorepo root
+cd apps/web && bun --bun run build           # produces apps/web/server
+```
+
+A full working monorepo + sharp example is in
+[Recipes › Monorepo + sharp](/next-bun-compile/recipes/monorepo-sharp/).
+
+## pnpm workspaces
+
+Same idea — pnpm's `.pnpm/` hoisted store is handled the same way as
+bun's `.bun/` store. The adapter walks both.
+
+## Turborepo
+
+Works as-is. If you use `turbo prune --docker` in CI to slim the
+Docker context, the pruned tree still triggers the nested-layout
+codepath. The adapter doesn't care about the workspace tool — only
+about the standalone layout Next.js produces.
+
+## What the adapter does for monorepos
+
+1. **Detects nested `server.js`.** `findServerDir` walks the standalone
+   to find your app's directory (e.g. `standalone/apps/web/`).
+2. **Walks nested `node_modules/`.** Monorepo standalone outputs often
+   have both `standalone/node_modules/` AND
+   `standalone/apps/web/node_modules/`. The adapter scans both for
+   externalized packages and stub placement.
+3. **Workspace packages survive.** Anything Next.js's trace pulled in
+   (including workspace `*`-version deps) gets extracted from
+   wherever it landed in the standalone.
+
+## Common gotchas
+
+### "Server.js not found anywhere"
+
+The adapter looks for `server.js` in the standalone tree but skips
+`node_modules`. If your app's `server.js` ends up under a path the
+search doesn't recognize, file an issue with the layout — we'll
+extend the detection.
+
+### Path-relative `import.meta.resolve` in next.config.ts
+
+Works the same in monorepos. The resolution happens at config-load
+time so the workspace's `node_modules` is what's consulted.
+
+### Mixed package managers
+
+If your CI installs with `bun` but your repo also has a stale
+`package-lock.json`, Next.js's "multiple lockfiles" warning may
+confuse workspace detection. Remove the unused lockfile.

--- a/docs/src/content/docs/guides/transpile-packages.mdx
+++ b/docs/src/content/docs/guides/transpile-packages.mdx
@@ -1,0 +1,80 @@
+---
+title: transpilePackages
+description: When and why to use Next.js's transpilePackages with packages that have dynamic requires.
+---
+
+## The problem
+
+Some npm packages use dynamic `require()` calls internally —
+typically for worker threads, transports, plugins, or conditional
+loading. Examples: `pino`, `pino-pretty`, packages that load
+plugins by string name.
+
+Turbopack can't statically resolve these dynamic requires, so it
+**externalizes** the package. At runtime in a compiled binary,
+those dynamic calls hit names like `require("pino-142500b1eb3f4baf")`
+that don't exist in any node_modules, and you see:
+
+```
+Failed to load external module pino-142500b1eb3f4baf:
+ResolveMessage: Cannot find package ...
+```
+
+## The fix
+
+Add the package to `transpilePackages` in your `next.config.ts`:
+
+```ts
+const nextConfig: NextConfig = {
+  transpilePackages: ["pino", "pino-pretty"],
+  adapterPath: import.meta.resolve("next-bun-compile"),
+};
+```
+
+This forces Turbopack to fully compile the package source rather
+than deferring its dynamic requires to runtime. The package code
+ends up bundled into your chunks — no externalization, no resolver
+gymnastics needed.
+
+## When you need it
+
+You'll hit this for packages that:
+
+- Use `require()` with computed/variable specifiers (`require(pluginName)`)
+- Spawn worker threads via `new Worker(__filename)` or similar
+- Conditionally load implementations by inspecting env vars at runtime
+
+Pure ESM imports and statically-analyzable `require("string-literal")`
+calls don't need this — they work fine externalized.
+
+## When NOT to use it
+
+`transpilePackages` doesn't work for **native modules** (anything
+that ships `.node` files or relies on dlopen). Native deps must stay
+externalized; that's what the resolver hook is for. Examples:
+
+- `sharp` — externalize, don't transpile
+- `bcrypt` — externalize, don't transpile
+- `better-sqlite3` — externalize, don't transpile
+
+For native deps with dynamic resolution, the runtime resolver hook
+handles things automatically. See
+[How it works](/next-bun-compile/how-it-works/).
+
+## Diagnosing whether a package needs it
+
+Symptom: runtime error of the form `Failed to load external module
+<pkg>-<16-hex-chars>`.
+
+To verify it's a "dynamic require" issue and not a missing-canonical
+issue:
+
+1. Run with `NEXT_BUN_COMPILE_VERBOSE=1` at **build** time. The
+   adapter prints every alias it discovered and whether it resolved.
+2. If the failing alias resolves cleanly at build but fails at runtime,
+   the dynamic-require path inside the package is hitting an
+   un-statically-analyzable code path.
+3. Add the package to `transpilePackages` and rebuild.
+
+If verbose output shows the alias **didn't** resolve at build, see
+[Troubleshooting: alias didn't resolve](/next-bun-compile/troubleshooting/#cannot-find-package-x-hex-or-x-hexsub).

--- a/docs/src/content/docs/how-it-works.mdx
+++ b/docs/src/content/docs/how-it-works.mdx
@@ -1,0 +1,128 @@
+---
+title: How It Works
+description: The architecture behind the binary — what the adapter does at build time, what the runtime does at boot.
+---
+
+## Pipeline
+
+1. **Adapter hook** — `modifyConfig()` flips `output: "standalone"`
+   automatically and writes a build-context file.
+2. **`next build`** runs your normal Next.js build, producing the
+   standalone tree under `.next/standalone/`.
+3. **`next-bun-compile` CLI** scans the standalone, discovers
+   externalized packages and turbopack-mangled aliases, generates
+   `server-entry.js` and `assets.generated.js`, then invokes
+   `bun build --compile`.
+4. **Bun compiles** everything (server code, embedded asset files,
+   bun runtime) into one binary with `--bytecode --minify`.
+
+## What gets embedded
+
+- All static files in `.next/static/` (skipped if `assetPrefix` set)
+- All public files
+- The `.next/server/` tree (chunks, manifests, build ID)
+- Every externalized server package — copied from your `node_modules/`
+  into the binary as file assets
+- A `server-entry.js` that extracts everything at first boot and
+  starts Next.js
+
+## Runtime: asset extraction
+
+On first run, the binary writes its embedded assets to disk relative
+to `process.execPath`. Subsequent runs see the files already there
+and skip re-extraction. Extraction is fast (~hundreds of ms for ~1500
+files) and idempotent.
+
+## Resolver hook for externalized packages
+
+This is where most of the interesting work happens. Next.js with
+Turbopack externalizes some packages (`sharp`, `bcrypt`, anything in
+`serverExternalPackages`, anything with native bindings) — they're
+loaded at runtime instead of bundled. Two things make that
+challenging in a compiled binary:
+
+1. **Mangled names.** Turbopack rewrites `require("sharp")` to
+   `require("sharp-457ea9eae1af1a9c")` in chunks, with a build-time
+   symlink at `.next/node_modules/sharp-457... → sharp`. The
+   compiled binary has no node_modules tree pre-baked.
+2. **Bun's compiled-binary resolver quirk.** From inside an extracted
+   `node_modules` entry (e.g. `sharp/lib/sharp.js`), bun's resolver
+   in compiled-binary mode doesn't reliably walk up to find sibling
+   packages. The same lookup works in `bun --bun next start` — it's
+   specific to compiled-binary mode.
+
+### Two mechanisms
+
+#### 1. Build-time chunk rewrite
+
+The adapter scans server chunks for `"<name>-<16 hex>"` string
+literals (the mangled-alias pattern) and replaces each with the
+absolute file path of the canonical target:
+
+```diff
+- require("sharp-457ea9eae1af1a9c")
++ require("__NBC_BASE__/.next/node_modules/sharp/lib/index.js")
+```
+
+`__NBC_BASE__` is a placeholder substituted with the real `baseDir`
+when `extractAssets` writes each chunk to disk. Resolution becomes a
+direct file load — no walks, no exports-map ambiguity, no resolver
+involvement. Works for both CJS `require()` and ESM `import()`.
+
+For subpath imports (`import("prettier-.../plugins/html")`), the
+adapter reads each canonical's `package.json` + `exports` map to
+pick the right `.mjs`/`.js`/`.cjs` variant, then rewrites to that
+absolute path.
+
+#### 2. Runtime `Module._resolveFilename` hook
+
+Once execution is inside an extracted package (sharp's own
+`require('detect-libc')`, the dynamic
+interpolated requires like `require('@img/sharp-PLATFORM/sharp.node')` (where `PLATFORM` is built from a runtime variable), the
+chunk rewrite no longer applies. A `Module._resolveFilename` hook
+catches CJS resolves that bun's compiled-binary resolver fails on
+and reimplements Node-compatible resolution from scratch:
+
+- Walk node_modules from the calling file
+- Read `package.json` + `main` for top-level
+- Honor `exports` maps (`require`/`node`/`default` conditions)
+- Handle directory subpaths with their own `package.json` +
+  `main` (e.g. `next/dist/compiled/source-map`)
+
+The hook also consults an alias map (`sharp-457... → sharp`) and
+redirects mangled names that slip past the build-time rewrite.
+
+Together: every externalized package's internal deps resolve through
+the same mechanism. No per-package patching needed for the common
+cases.
+
+## Module stubs (dev-only code paths)
+
+Some modules can't be resolved at compile time but are never reached
+in production — Next's dev server, the dev bundler, optional deps
+loaded in try/catch. The adapter creates no-op stubs for these
+**only if** the real module isn't installed. If you do install
+`@opentelemetry/api` or `critters`, the real package gets bundled
+instead.
+
+## Pre-flight validator (build time)
+
+For every alias + subpath the chunks reference, the adapter checks
+whether resolution found a file. If anything didn't resolve, it
+warns at build time:
+
+```
+next-bun-compile: ⚠ 1 of 4 turbopack alias reference(s) won't resolve at runtime:
+  ✗ some-pkg-deadbeef/foo → some-pkg/foo
+```
+
+Set `NEXT_BUN_COMPILE_VERBOSE=1` during build to see every
+resolution + the file it picked — useful for verifying exports-map
+handling chose the right variant.
+
+## Debug mode (runtime)
+
+Set `NEXT_BUN_COMPILE_DEBUG=1` when running the binary to log every
+resolver-hook decision: alias redirects, fallback walks, fallback
+failures, with parent-file context. See
+[Debug mode](/next-bun-compile/guides/debug-mode/).

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -1,0 +1,91 @@
+---
+title: next-bun-compile
+description: Compile Next.js apps into single-file Bun executables. One command. One binary. No runtime dependencies.
+template: splash
+hero:
+  tagline: A Next.js Build Adapter that compiles your app into a single-file Bun executable. One command, one binary, no runtime dependencies.
+  actions:
+    - text: Get Started
+      link: /next-bun-compile/getting-started/
+      icon: right-arrow
+      variant: primary
+    - text: View on GitHub
+      link: https://github.com/ramonmalcolm10/next-bun-compile
+      icon: external
+      variant: minimal
+      attrs:
+        target: _blank
+        rel: noopener
+---
+
+import { Card, CardGrid } from "@astrojs/starlight/components";
+
+## Why next-bun-compile?
+
+<CardGrid>
+  <Card title="One binary, ship anywhere" icon="rocket">
+    `next build` produces a single `./server` executable with every
+    static asset, public file, and runtime chunk embedded. Copy it to
+    a distroless image, scp it to a VM, attach it to a release —
+    that's the deploy.
+  </Card>
+  <Card title="Faster cold start" icon="random">
+    Bun's `--bytecode` flag pre-compiles JavaScript at build time so
+    parsing is skipped at boot. Real Next.js apps start ~2x faster
+    than `next start` on the same runtime.
+  </Card>
+  <Card title="Smaller image footprint" icon="seti:zip">
+    ~30MB binary on distroless beats ~150MB for `bun + standalone`
+    setups. For native deps like sharp, the runner adds the C runtime
+    libs and you're at ~80MB total.
+  </Card>
+  <Card title="Native deps just work" icon="puzzle">
+    sharp, bcrypt, better-sqlite3 — handled. A runtime resolver hook
+    + build-time chunk rewrite makes externalized packages resolve
+    cleanly from inside the compiled binary, with no per-package
+    configuration.
+  </Card>
+  <Card title="Monorepo aware" icon="seti:folder">
+    Bun workspaces, pnpm workspaces, Turborepo all work. The standalone
+    trace's nested layout (`standalone/apps/web/server.js`) is handled
+    correctly out of the box.
+  </Card>
+  <Card title="Works with what you already use" icon="approve-check">
+    Drops into your existing `next.config.ts` via `adapterPath`. No
+    changes to your app code, no opinions about your routing or data
+    layer.
+  </Card>
+</CardGrid>
+
+## Quick start
+
+```bash
+bun add -D next-bun-compile
+```
+
+```ts
+// next.config.ts
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {
+  adapterPath: import.meta.resolve("next-bun-compile"),
+};
+
+export default nextConfig;
+```
+
+```json
+// package.json
+{
+  "scripts": {
+    "build": "next build && next-bun-compile"
+  }
+}
+```
+
+```bash
+bun run build    # → ./server
+./server         # serves on port 3000
+```
+
+Full walkthrough in [Getting Started](/next-bun-compile/getting-started/).

--- a/docs/src/content/docs/recipes/distroless-sharp.mdx
+++ b/docs/src/content/docs/recipes/distroless-sharp.mdx
@@ -1,0 +1,112 @@
+---
+title: Distroless + sharp
+description: Complete Dockerfile recipe — compile a Next.js app that uses sharp, ship on gcr.io/distroless/cc-debian12 with fontconfig for libvips text rendering.
+---
+
+import { Code } from "@astrojs/starlight/components";
+
+A minimal Next.js app that uses `sharp` (the dep `next/image`
+server-side optimization pulls in), compiled to a single binary and
+shipped on `gcr.io/distroless/cc-debian12`. Final image ~80MB.
+
+This is the recipe **and** the e2e regression test — CI builds and
+boots it on every PR.
+
+The full working source is in
+[`examples/sharp/`](https://github.com/ramonmalcolm10/next-bun-compile/tree/main/examples/sharp)
+in the repo.
+
+## Dockerfile
+
+```dockerfile
+# Stage 1: Build the binary
+FROM oven/bun:1.3.14 AS builder
+
+WORKDIR /app
+
+COPY package.json bun.lock* ./
+RUN bun install --no-save
+
+COPY . .
+
+# Install fontconfig + fonts in the builder so we can copy the
+# artifacts into the distroless runner. The build itself doesn't
+# need them, but fc-cache populates /var/cache/fontconfig with a
+# fresh font cache the runner can use directly.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends fontconfig fonts-dejavu-core \
+ && fc-cache -f \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN bun --bun run build
+
+# Stage 2: Run the compiled binary
+FROM gcr.io/distroless/cc-debian12:nonroot AS runner
+
+WORKDIR /app
+
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+ENV HOSTNAME="0.0.0.0"
+
+# Self-contained binary
+COPY --from=builder --chown=nonroot:nonroot /app/server ./
+
+# Fontconfig + fonts + the C libs libvips dlopens for text rendering.
+# cc-debian12 already has libstdc++ and libgcc; these complete the
+# set.
+COPY --from=builder /etc/fonts /etc/fonts
+COPY --from=builder /usr/share/fontconfig /usr/share/fontconfig
+COPY --from=builder /usr/share/fonts /usr/share/fonts
+COPY --from=builder /var/cache/fontconfig /var/cache/fontconfig
+COPY --from=builder /usr/lib/x86_64-linux-gnu/libfontconfig.so* /usr/lib/x86_64-linux-gnu/
+COPY --from=builder /usr/lib/x86_64-linux-gnu/libfreetype.so* /usr/lib/x86_64-linux-gnu/
+COPY --from=builder /usr/lib/x86_64-linux-gnu/libexpat.so* /usr/lib/x86_64-linux-gnu/
+COPY --from=builder /usr/lib/x86_64-linux-gnu/libpng16.so* /usr/lib/x86_64-linux-gnu/
+
+EXPOSE 3000
+CMD ["./server"]
+```
+
+## Why each piece
+
+| Block                                                | Why                                                                                                                                       |
+| ---------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `oven/bun:1.3.14` builder                            | Builds the binary. Debian-based so `apt-get` works.                                                                                       |
+| `apt-get install fontconfig fonts-dejavu-core`       | libvips needs fontconfig + a font face for text rendering (watermarks, captions). Skip if you only do non-text sharp ops.                |
+| `fc-cache -f`                                        | Populates `/var/cache/fontconfig` so the runner doesn't have to rebuild the cache on first text-render.                                  |
+| `bun --bun run build`                                | `next build` + `next-bun-compile` → `./server`.                                                                                          |
+| `gcr.io/distroless/cc-debian12:nonroot`              | Has glibc + libstdc++ + libgcc (the `cc` variant). The plain `base` variant lacks libstdc++ and sharp won't load.                       |
+| `COPY /etc/fonts /usr/share/fontconfig ... /var/cache/fontconfig` | All the data fontconfig expects. Drop if you don't render text.                                                            |
+| `COPY libfontconfig + libfreetype + libexpat + libpng16` | Runtime libs libvips dlopens. Same caveat as fonts.                                                                                  |
+
+## If you don't need text rendering
+
+Drop the `apt-get install fontconfig fonts-dejavu-core`, the
+`fc-cache` line, and all the `COPY /etc/fonts`-and-friends blocks.
+Shrinks the image by ~5MB.
+
+## Different font face
+
+Swap `fonts-dejavu-core` for whatever package provides the font your
+watermark text uses:
+
+- `fonts-liberation` (Arial/Helvetica/Times metric-compatible)
+- `fonts-noto-core` (Noto fonts, broad Unicode coverage)
+- `fonts-roboto`
+
+## Other architectures
+
+Pass `--target=bun-linux-arm64` to `next-bun-compile` in the build
+script. See [Cross-compilation](/next-bun-compile/guides/cross-compilation/).
+
+## Variants
+
+- **alpine + bun runtime instead.** If you want to skip compilation
+  altogether: use `oven/bun:1.3.14-alpine`, `apk add fontconfig
+  ttf-dejavu`, `COPY .next/standalone .`, `CMD ["bun",
+  "apps/web/server.js"]`. Larger image (~150MB), no compile step,
+  same resolution behavior because it's the standard bun runtime.
+
+- **Monorepo layout** with this same recipe — see
+  [Monorepo + sharp](/next-bun-compile/recipes/monorepo-sharp/).

--- a/docs/src/content/docs/recipes/monorepo-sharp.mdx
+++ b/docs/src/content/docs/recipes/monorepo-sharp.mdx
@@ -1,0 +1,115 @@
+---
+title: Monorepo + sharp
+description: Complete Dockerfile recipe — bun workspaces monorepo (app + shared package) with sharp, on distroless.
+---
+
+A bun-workspaces monorepo with one Next.js app (`apps/web`) and one
+shared package (`packages/shared`). The web app uses sharp + the
+shared package and is compiled to a single binary on
+`gcr.io/distroless/cc-debian12`.
+
+This recipe doubles as the e2e regression test for two things at
+once:
+
+1. **Nested standalone layout** — Next.js produces
+   `apps/web/.next/standalone/apps/web/server.js`, not
+   `standalone/server.js`. The adapter handles the nesting
+   automatically.
+2. **Workspace package resolution** — `@example/shared` is a
+   workspace-versioned dep. It survives the standalone trace
+   round-trip into the binary.
+
+Full source in
+[`examples/monorepo/`](https://github.com/ramonmalcolm10/next-bun-compile/tree/main/examples/monorepo).
+
+## Project layout
+
+```
+monorepo/
+├── package.json              # workspaces: ["apps/*", "packages/*"]
+├── apps/
+│   └── web/
+│       ├── app/api/resize/route.ts  # uses sharp + @example/shared
+│       ├── next.config.ts
+│       └── package.json
+├── packages/
+│   └── shared/
+│       ├── index.ts          # exports pickColor(seed)
+│       └── package.json
+└── Dockerfile
+```
+
+## Dockerfile
+
+```dockerfile
+FROM oven/bun:1.3.14 AS builder
+
+WORKDIR /app
+
+# Workspace setup: root package.json + all workspace package.jsons
+# need to be present before `bun install` so the workspace graph
+# resolves. Copy them all first, then install once.
+COPY package.json bun.lock* ./
+COPY apps/web/package.json ./apps/web/
+COPY packages/shared/package.json ./packages/shared/
+RUN bun install --no-save
+
+# Now copy the source code
+COPY . .
+
+# Fontconfig + fonts for sharp/libvips text rendering. Skip if your
+# sharp usage is resize/format-only.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends fontconfig fonts-dejavu-core \
+ && fc-cache -f \
+ && rm -rf /var/lib/apt/lists/*
+
+# Build the web app — produces apps/web/server (single binary)
+RUN cd apps/web && bun --bun run build
+
+# Runner: distroless with libstdc++ + fontconfig
+FROM gcr.io/distroless/cc-debian12:nonroot AS runner
+
+WORKDIR /app
+
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+ENV HOSTNAME="0.0.0.0"
+
+COPY --from=builder --chown=nonroot:nonroot /app/apps/web/server ./
+
+COPY --from=builder /etc/fonts /etc/fonts
+COPY --from=builder /usr/share/fontconfig /usr/share/fontconfig
+COPY --from=builder /usr/share/fonts /usr/share/fonts
+COPY --from=builder /var/cache/fontconfig /var/cache/fontconfig
+COPY --from=builder /usr/lib/x86_64-linux-gnu/libfontconfig.so* /usr/lib/x86_64-linux-gnu/
+COPY --from=builder /usr/lib/x86_64-linux-gnu/libfreetype.so* /usr/lib/x86_64-linux-gnu/
+COPY --from=builder /usr/lib/x86_64-linux-gnu/libexpat.so* /usr/lib/x86_64-linux-gnu/
+COPY --from=builder /usr/lib/x86_64-linux-gnu/libpng16.so* /usr/lib/x86_64-linux-gnu/
+
+EXPOSE 3000
+CMD ["./server"]
+```
+
+## Build it
+
+```bash
+docker build -t next-bun-compile-monorepo .
+docker run --rm -p 3000:3000 next-bun-compile-monorepo
+```
+
+## Adapting to your monorepo
+
+- **Turborepo / Nx.** Same recipe — the adapter cares about the
+  standalone layout, not the workspace tool. If you use
+  `turbo prune --docker` in CI to slim the Docker context, the
+  pruned tree still works.
+- **pnpm workspaces.** Works. The `.pnpm/` hoisted store is handled
+  by the same code as the `.bun/` store.
+- **Many apps in one repo.** The adapter scopes to whatever app's
+  `next build` you run; it doesn't try to detect siblings. Build
+  each app independently.
+- **Workspace dep changed but binary stale?** `next build` doesn't
+  rebuild on workspace-package changes by default. Add the workspace
+  package to `transpilePackages` (or rely on file watching during
+  development) if you hit this.

--- a/docs/src/content/docs/troubleshooting.mdx
+++ b/docs/src/content/docs/troubleshooting.mdx
@@ -1,0 +1,108 @@
+---
+title: Troubleshooting
+description: Common errors and their fixes when building or running a next-bun-compile binary.
+---
+
+## Stale standalone output after upgrading Next.js
+
+Next.js doesn't clean its standalone output between builds. If you
+upgrade Next.js, stale files from the old version can cause runtime
+errors like `Cannot find module 'next/dist/compiled/source-map'`.
+
+**Fix.** Clean before rebuilding:
+
+```bash
+rm -rf .next/standalone && bun run build
+```
+
+## `Failed to load external module pino-...: Cannot find package`
+
+Some packages (`pino`, `pino-pretty`) use dynamic `require()` calls
+internally that Turbopack can't statically resolve. They get
+externalized with a mangled name that doesn't exist in your
+node_modules.
+
+**Fix.** Force them through the bundler with `transpilePackages`:
+
+```ts
+const nextConfig: NextConfig = {
+  transpilePackages: ["pino", "pino-pretty"],
+  adapterPath: import.meta.resolve("next-bun-compile"),
+};
+```
+
+See [transpilePackages guide](/next-bun-compile/guides/transpile-packages/).
+
+## `Could not load the "sharp" module using the linux-x64 runtime`
+
+Sharp loaded but couldn't dlopen its native binding. This is sharp's
+own error after exhausting its load paths — it's a runtime
+environment issue, not a next-bun-compile issue.
+
+**Fix.** Use a runner image with the libs sharp's prebuilt expects:
+
+- `gcr.io/distroless/cc-debian12:nonroot` — has `libstdc++` (the
+  `cc` variant). The plain `base` variant lacks `libstdc++` and
+  sharp won't load.
+- For text rendering (watermarks): also need fontconfig + a font
+  face. Full recipe in
+  [Distroless + sharp](/next-bun-compile/recipes/distroless-sharp/).
+
+## `Fontconfig error: Cannot load default config file`
+
+libvips (sharp's image engine) needs fontconfig + actual font files
+to render text. Distroless images don't include either.
+
+**Fix.** Copy them from the builder. See the recipe section in
+[Distroless + sharp](/next-bun-compile/recipes/distroless-sharp/).
+
+## Binary boots, then 500 on first request
+
+Often a missing env var your app needs at runtime — check what's
+required and ensure the deploy sets them. Common cases:
+
+- `DATABASE_URL` or similar (no value → driver crashes on first use)
+- Stripe / OAuth secrets your code expects
+
+**Diagnostic.** Set `NEXT_BUN_COMPILE_DEBUG=1` and re-run; the log
+will show every resolver-hook decision so you can rule out a
+resolution failure.
+
+## "Cannot find package 'X-abc123...'" with a 16-char hex suffix
+
+A turbopack-mangled alias the resolver couldn't redirect. The
+build-time validator should have warned about this — check the
+build log for:
+
+```
+next-bun-compile: ⚠ N of M turbopack alias reference(s) won't resolve at runtime:
+  ✗ X-abc123def456... → X
+```
+
+**Fix.** The canonical package isn't in the standalone tree. Either:
+
+- Add it as a dependency
+- Or add it to `transpilePackages` so it's bundled into the chunks
+  instead of externalized
+
+## Want to see what's happening at runtime?
+
+```bash
+NEXT_BUN_COMPILE_DEBUG=1 ./server
+```
+
+Logs every resolver-hook decision with parent-file context. See
+[Debug mode](/next-bun-compile/guides/debug-mode/) for output
+examples and how to read them.
+
+## Still stuck?
+
+Open an issue with:
+
+1. The error output
+2. `NEXT_BUN_COMPILE_DEBUG=1` log of the failing request (if it
+   happens at runtime)
+3. Your `next.config.ts`
+4. A list of native deps in your `package.json`
+
+[Open an issue →](https://github.com/ramonmalcolm10/next-bun-compile/issues/new)

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "astro/tsconfigs/strict"
+}


### PR DESCRIPTION
## Summary

Astro 6 + Starlight 0.40 documentation site under \`docs/\`, deployed to GitHub Pages at https://ramonmalcolm10.github.io/next-bun-compile/.

## What's in the diff

- \`docs/\` — Starlight project (package.json, astro.config.mjs, content collection, SocialIcons component)
- 12 content pages covering everything currently scattered across READMEs, recipes, and commit messages:
  - **Start Here:** Getting Started, Configuration, How It Works, Troubleshooting
  - **Guides:** Cross-compilation, Docker, Monorepos, transpilePackages, Debug mode
  - **Recipes:** Distroless + sharp, Monorepo + sharp (mirror \`examples/\` READMEs)
- \`.github/workflows/docs.yml\` — deploys to GitHub Pages on push to main when \`docs/\` changes
- \`README.md\` — adds a docs link at the top

## After merge

1. Enable GitHub Pages for the repo (Settings → Pages → Source: GitHub Actions)
2. The deploy workflow fires on next push to main touching \`docs/**\`
3. Site lands at https://ramonmalcolm10.github.io/next-bun-compile/

## Test plan

- [x] Site builds locally with \`bun run build\` (13 pages generated, sitemap + Pagefind search index)
- [x] Same Astro/Starlight versions as the existing ideal-auth docs setup, with Astro 6 / Starlight 0.40 adjustments (\`docsLoader\` import, new autogenerate sidebar syntax)

## Notes

This is purely additive — no runtime code touched, no behavioral changes for users of the npm package. Safe to merge any time independent of the other open PRs.