### PR TITLE
Add VPS deploy recipe (GitHub Actions → scp → systemd)

### DIFF
--- a/docs/src/content/docs/recipes/vps-deploy.mdx
+++ b/docs/src/content/docs/recipes/vps-deploy.mdx
@@ -1,0 +1,217 @@
+---
+title: Deploy to a VPS with zero runtime dependencies
+description: Build the binary in GitHub Actions, ship it to a VPS over SSH, run under systemd. The VPS needs nothing installed but ssh, systemd, and a working glibc.
+---
+
+import { Steps } from "@astrojs/starlight/components";
+
+The single-binary deploy story: a Linux executable built in CI, `scp`'d
+to your VPS, run under systemd. The VPS needs **nothing installed but
+ssh, systemd, and a working glibc** — no node, no bun, no
+node_modules. No Docker.
+
+Full working source in
+[`examples/vps-deploy/`](https://github.com/ramonmalcolm10/next-bun-compile/tree/main/examples/vps-deploy)
+— GitHub Actions workflow, systemd unit, README with one-time setup.
+
+## When this is the right answer
+
+- You want **predictable monthly costs**. A $4–6/mo VPS comfortably
+  runs a real Next.js app. No per-invocation fees, no platform
+  surprises.
+- You want **zero lock-in**. The deploy artifact is one file you
+  control end-to-end.
+- You want a **simple operational model**. systemd restarts on crash,
+  caddy in front handles TLS, that's the entire stack.
+- You don't want a Docker daemon on the VPS, or a build pipeline
+  that needs `docker login` / image registry credentials.
+
+If you want autoscaling, multi-region, or the Vercel feature set,
+this isn't the recipe — use Vercel or a container platform instead.
+
+## How it works
+
+<Steps>
+
+1. ### GitHub Actions builds the binary
+
+   `bun --bun run build:linux-x64` cross-compiles to a single Linux
+   binary regardless of the runner architecture. Produces a ~30MB
+   `./server` artifact.
+
+2. ### scp the binary to the VPS
+
+   The workflow uploads to a staging filename (`server.new`) instead
+   of overwriting `server` directly. `scp` writing to the live binary
+   would briefly leave it truncated if the transfer were interrupted.
+
+3. ### Atomic swap + restart
+
+   Over SSH:
+
+   ```bash
+   mv -f server.new server          # atomic on same filesystem
+   rm -rf .next public              # wipe stale extracted assets
+   sudo systemctl restart next-app  # the unit picks up the new binary
+   ```
+
+   `mv` within a filesystem is atomic at the inode level — readers
+   either see the old binary or the new one, never a half-written
+   file. The `rm -rf` of extracted assets is belt-and-suspenders:
+   `extractAssets` is idempotent and won't overwrite files that
+   already exist, so without the wipe stale chunks from the previous
+   deploy would linger.
+
+4. ### Smoke test
+
+   The workflow polls `/api/healthz` for up to 30s after restart. If
+   it doesn't come back 200, the workflow fails — you find out about
+   broken rollouts in CI, not from your users.
+
+</Steps>
+
+## VPS setup (one-time)
+
+Pick any VPS that runs systemd and ships glibc — Ubuntu, Debian,
+Rocky, anything modern.
+
+<Steps>
+
+1. ### Create a deploy user
+
+   ```bash
+   sudo useradd -r -m -s /bin/bash -d /srv/next-app deploy
+   sudo mkdir -p /srv/next-app
+   sudo chown -R deploy:deploy /srv/next-app
+   ```
+
+2. ### Generate a deploy SSH key
+
+   On your laptop (don't reuse a personal key):
+
+   ```bash
+   ssh-keygen -t ed25519 -f ~/.ssh/next-app-deploy -N ""
+   cat ~/.ssh/next-app-deploy.pub
+   ```
+
+   On the VPS, add the public key to `deploy`'s authorized_keys.
+
+3. ### Allow `deploy` to restart the service
+
+   ```bash
+   sudo visudo -f /etc/sudoers.d/deploy-next-app
+   ```
+
+   ```
+   deploy ALL=(root) NOPASSWD: /bin/systemctl restart next-app
+   ```
+
+4. ### Install the systemd unit
+
+   The unit file is at `examples/vps-deploy/systemd/next-app.service`
+   in the repo. Copy it to the VPS, then:
+
+   ```bash
+   sudo cp next-app.service /etc/systemd/system/
+   sudo systemctl daemon-reload
+   sudo systemctl enable next-app
+   ```
+
+   Don't start yet — there's no binary in `/srv/next-app/server` until
+   the first deploy.
+
+5. ### (Recommended) Put caddy in front for TLS
+
+   ```bash
+   sudo apt install caddy
+   ```
+
+   `/etc/caddy/Caddyfile`:
+
+   ```caddyfile
+   example.com {
+     reverse_proxy 127.0.0.1:3000
+   }
+   ```
+
+   Caddy handles HTTPS via Let's Encrypt automatically.
+
+</Steps>
+
+## Repo secrets + variables
+
+In repo Settings → Secrets and variables → Actions:
+
+**Secrets:**
+
+| Name              | Value                                                  |
+|-------------------|--------------------------------------------------------|
+| `VPS_HOST`        | `example.com` or VPS IP                                |
+| `VPS_USER`        | `deploy`                                               |
+| `VPS_SSH_KEY`     | contents of `~/.ssh/next-app-deploy` (the private key) |
+| `VPS_KNOWN_HOSTS` | `ssh-keyscan example.com` — pin the host key           |
+
+**Variables:**
+
+| Name           | Value           |
+|----------------|-----------------|
+| `APP_DIR`      | `/srv/next-app` |
+| `SERVICE_NAME` | `next-app`      |
+
+## Native dependencies (sharp, etc.)
+
+The binary loads native bindings just fine on any glibc-based VPS.
+For sharp's text rendering features specifically (watermarks),
+install fontconfig + a font face on the VPS:
+
+```bash
+sudo apt install fontconfig fonts-dejavu-core
+```
+
+No fancier setup required.
+
+## Why not Docker?
+
+Docker on a VPS is fine — it just adds layers (the daemon, an image
+registry, image pulls on every deploy). The single-binary approach
+is what makes "skip Docker" reasonable:
+
+| | Docker on VPS | next-bun-compile + scp |
+|---|---|---|
+| Per-deploy transfer | image pull (~50–200MB) | one binary (~30MB) |
+| Daemon process | yes, always | none |
+| Registry creds | yes | none |
+| Rollback | re-pull old tag | `mv` the previous binary back |
+
+If you already have a Docker pipeline you like, keep it. The
+[Distroless + sharp recipe](/next-bun-compile/recipes/distroless-sharp/)
+shows the container path.
+
+## Multi-app, multi-arch, no-reverse-proxy variants
+
+- **Multiple apps on one VPS:** each gets its own user, its own
+  `WorkingDirectory`, and its own systemd unit. Caddy in front
+  handles host-based routing.
+- **ARM VPS** (Hetzner, Oracle, AWS Graviton): swap
+  `build:linux-x64` for `build:linux-arm64` in the workflow.
+- **Skip the reverse proxy:** set `HOSTNAME=0.0.0.0` and
+  `PORT=80` in the unit, plus
+  `AmbientCapabilities=CAP_NET_BIND_SERVICE` to bind a privileged
+  port as non-root. You're now responsible for TLS — most people
+  shouldn't.
+
+## Rollback
+
+The previous binary is gone (`mv` overwrote it). If you need
+rollback insurance, change the workflow to keep one backup:
+
+```bash
+mv -f server server.prev
+mv -f server.new server
+```
+
+Then `mv -f server.prev server && sudo systemctl restart next-app`
+rolls back instantly.
+
+For more sophisticated rollouts (canary, blue/green), you've outgrown
+"one VPS + systemd" — time to look at a container platform.

--- a/examples/README.md
+++ b/examples/README.md
@@ -8,6 +8,7 @@ real environments. Each example is also an e2e regression test —
 |---|---|
 | [`sharp/`](./sharp) | distroless + `sharp` on a single Next.js app. The most common starting point for an app with native image processing. Includes fontconfig setup for libvips text rendering. |
 | [`monorepo/`](./monorepo) | bun workspaces monorepo (one app, one shared package) with `sharp`. Demonstrates the nested-standalone layout (`standalone/apps/web/server.js`) and workspace dep resolution from the binary. |
+| [`vps-deploy/`](./vps-deploy) | Deploy to a VPS via GitHub Actions + SSH + systemd. The VPS needs nothing installed but ssh, systemd, and glibc — no node, no bun, no Docker. Includes the deploy workflow, the systemd unit, and full one-time-setup README. |
 
 ## How to use a recipe
 

--- a/examples/vps-deploy/.github/workflows/deploy.yml
+++ b/examples/vps-deploy/.github/workflows/deploy.yml
@@ -1,0 +1,107 @@
+# Build the Next.js app into a single Linux binary and ship it to a
+# VPS over SSH. The VPS needs nothing installed but ssh, systemd, and
+# a working glibc — no node, no bun, no node_modules.
+#
+# Required repo secrets:
+#   VPS_HOST        e.g. example.com or 1.2.3.4
+#   VPS_USER        e.g. deploy
+#   VPS_SSH_KEY     the private key contents for the VPS_USER account
+#   VPS_KNOWN_HOSTS output of `ssh-keyscan VPS_HOST` (pin to avoid MITM)
+#
+# Required repo variables:
+#   APP_DIR         absolute path on the VPS, e.g. /srv/next-app
+#   SERVICE_NAME    systemd unit name, e.g. next-app
+#
+# Assumes the systemd unit from `systemd/next-app.service` is already
+# installed and enabled. First-time setup is in the README.
+
+name: Deploy to VPS
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: vps-deploy
+  cancel-in-progress: false # finish one rollout before starting the next
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: '1.3.14'
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build linux-x64 binary
+        run: bun --bun run build:linux-x64
+        # Produces ./server — a ~30MB single executable.
+
+      - name: Configure SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.VPS_SSH_KEY }}" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          echo "${{ secrets.VPS_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
+          chmod 644 ~/.ssh/known_hosts
+
+      - name: Upload binary to VPS
+        env:
+          VPS_USER: ${{ secrets.VPS_USER }}
+          VPS_HOST: ${{ secrets.VPS_HOST }}
+          APP_DIR: ${{ vars.APP_DIR }}
+        run: |
+          # Upload to a staging name first, then atomic-rename into place
+          # on the VPS so a partial transfer can never leave the service
+          # pointing at a truncated file.
+          scp -i ~/.ssh/id_ed25519 ./server \
+            "$VPS_USER@$VPS_HOST:$APP_DIR/server.new"
+
+      - name: Atomic swap + restart service
+        env:
+          VPS_USER: ${{ secrets.VPS_USER }}
+          VPS_HOST: ${{ secrets.VPS_HOST }}
+          APP_DIR: ${{ vars.APP_DIR }}
+          SERVICE_NAME: ${{ vars.SERVICE_NAME }}
+        run: |
+          ssh -i ~/.ssh/id_ed25519 "$VPS_USER@$VPS_HOST" bash -se <<EOF
+          set -euo pipefail
+          cd "$APP_DIR"
+
+          # `mv` within the same filesystem is atomic. Even mid-restart,
+          # readers either see the old binary or the new one — never a
+          # partial file.
+          chmod +x server.new
+          mv -f server.new server
+
+          # Wipe extracted assets so the new binary re-extracts its own.
+          # next-bun-compile's extractAssets is idempotent and skips
+          # files that already exist on disk, so without this the
+          # binary would reuse stale chunks from the previous deploy.
+          rm -rf .next public
+
+          sudo systemctl restart "$SERVICE_NAME"
+          EOF
+
+      - name: Smoke test
+        env:
+          VPS_HOST: ${{ secrets.VPS_HOST }}
+        run: |
+          # Give systemd a beat to start the process, then hit healthz.
+          # If we don't get a 200 in 30s, the rollout failed.
+          for i in $(seq 1 30); do
+            if curl -fsS -o /dev/null "https://$VPS_HOST/api/healthz"; then
+              echo "✅ deploy live"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "❌ healthz never came back 200"
+          exit 1

--- a/examples/vps-deploy/.gitignore
+++ b/examples/vps-deploy/.gitignore
@@ -1,0 +1,8 @@
+node_modules
+.next
+server
+server-entry.js*
+assets.generated.js
+.*.bun-build
+next-env.d.ts
+bun.lock

--- a/examples/vps-deploy/README.md
+++ b/examples/vps-deploy/README.md
@@ -1,0 +1,172 @@
+# Example: deploy to a VPS with zero runtime dependencies
+
+Build the Next.js app into a single Linux binary in GitHub Actions, ship
+it to a VPS over SSH, run it under systemd. The VPS needs nothing
+installed but ssh, systemd, and a working glibc — no node, no bun, no
+node_modules. No package manager, no Docker.
+
+## Why
+
+| | Vercel | bun next start on VPS | `next-bun-compile` on VPS |
+|---|---|---|---|
+| Runtime deps on VPS | n/a | bun + node_modules + nm tree | nothing — just the binary |
+| Deploy artifact | git push | rsync dir tree (~150MB) | scp one file (~30MB) |
+| Zero-downtime swap | automatic | restart bun process | atomic mv + systemctl restart |
+| Lock-in | platform | none | none |
+
+## What's here
+
+```
+vps-deploy/
+├── app/                         # the Next.js app (minimal)
+│   ├── api/healthz/route.ts     # readiness endpoint for the smoke test
+│   ├── layout.tsx
+│   └── page.tsx
+├── next.config.ts               # adapterPath: next-bun-compile
+├── package.json                 # build:linux-x64 / build:linux-arm64 scripts
+├── .github/workflows/
+│   └── deploy.yml               # the build + ship workflow
+├── systemd/
+│   └── next-app.service         # the unit file (one-time install on VPS)
+└── README.md                    # this file
+```
+
+## VPS one-time setup
+
+Pick any VPS that runs systemd and ships glibc — Ubuntu, Debian, Rocky,
+anything modern. The smallest tier ($4–6/mo) is fine for most apps.
+
+1. **Create a deploy user.** SSH in as root:
+
+   ```bash
+   sudo useradd -r -m -s /bin/bash -d /srv/next-app deploy
+   sudo mkdir -p /srv/next-app
+   sudo chown -R deploy:deploy /srv/next-app
+   ```
+
+2. **Authorize the GitHub Actions SSH key.** Generate a new key on
+   your laptop (don't reuse a personal one):
+
+   ```bash
+   ssh-keygen -t ed25519 -f ~/.ssh/next-app-deploy -N ""
+   cat ~/.ssh/next-app-deploy.pub
+   ```
+
+   On the VPS, add the public key to `deploy`'s authorized_keys:
+
+   ```bash
+   sudo -u deploy mkdir -p /srv/next-app/.ssh
+   sudo -u deploy bash -c 'echo "PASTE-PUBLIC-KEY-HERE" >> /srv/next-app/.ssh/authorized_keys'
+   sudo chmod 700 /srv/next-app/.ssh
+   sudo chmod 600 /srv/next-app/.ssh/authorized_keys
+   ```
+
+3. **Grant systemd restart privilege to the deploy user** via a
+   minimal sudoers rule (no general sudo):
+
+   ```bash
+   sudo visudo -f /etc/sudoers.d/deploy-next-app
+   ```
+
+   Paste:
+
+   ```
+   deploy ALL=(root) NOPASSWD: /bin/systemctl restart next-app, /bin/systemctl status next-app
+   ```
+
+4. **Install the systemd unit:**
+
+   ```bash
+   sudo cp systemd/next-app.service /etc/systemd/system/
+   sudo systemctl daemon-reload
+   sudo systemctl enable next-app
+   # Don't start yet — there's no binary in /srv/next-app/server.
+   # The first GitHub Actions run will deploy + restart.
+   ```
+
+5. **(Optional but recommended) Put caddy in front for TLS:**
+
+   ```bash
+   sudo apt install caddy
+   ```
+
+   `/etc/caddy/Caddyfile`:
+
+   ```
+   example.com {
+     reverse_proxy 127.0.0.1:3000
+   }
+   ```
+
+   ```bash
+   sudo systemctl reload caddy
+   ```
+
+   Caddy handles HTTPS certs automatically via Let's Encrypt.
+
+## GitHub repo setup
+
+In repo Settings → Secrets and variables → Actions, add:
+
+**Secrets:**
+
+| Name              | Value                                                    |
+|-------------------|----------------------------------------------------------|
+| `VPS_HOST`        | `example.com` or VPS IP                                  |
+| `VPS_USER`        | `deploy`                                                 |
+| `VPS_SSH_KEY`     | contents of `~/.ssh/next-app-deploy` (the private key)   |
+| `VPS_KNOWN_HOSTS` | output of `ssh-keyscan example.com` — pin the host key   |
+
+**Variables:**
+
+| Name           | Value                |
+|----------------|----------------------|
+| `APP_DIR`      | `/srv/next-app`      |
+| `SERVICE_NAME` | `next-app`           |
+
+## Deploy
+
+Push to `main`. The workflow:
+
+1. Checks out + installs deps + builds the Linux binary with
+   `bun --bun run build:linux-x64`.
+2. `scp`s the binary to `$APP_DIR/server.new` on the VPS.
+3. Over SSH: atomically `mv server.new server`, `rm -rf .next public`,
+   `sudo systemctl restart next-app`.
+4. Polls `https://$VPS_HOST/api/healthz` for up to 30s — fails the
+   workflow if it doesn't come back 200.
+
+### Why the `rm -rf .next public`?
+
+`extractAssets` is idempotent and skips files that already exist on
+disk. Without the wipe, files from the previous deploy that don't
+exist in the new binary would linger. Cheap insurance for a clean
+filesystem state.
+
+### Why a separate `server.new` then `mv`?
+
+`mv` within the same filesystem is atomic. Even if the binary is
+mid-restart, readers either see the old binary or the new one —
+never a partially-written file. `scp` writing directly to `server`
+would briefly leave the binary truncated.
+
+## Variants
+
+- **ARM VPS (Hetzner, Oracle, AWS Graviton):** swap
+  `build:linux-x64` for `build:linux-arm64` in the workflow.
+- **Native deps (sharp, bcrypt, etc.):** the binary loads them just
+  fine on any glibc-based VPS. For sharp's text rendering features
+  (watermarks), the VPS additionally needs fontconfig + a font face:
+  `sudo apt install fontconfig fonts-dejavu-core`.
+- **Multiple apps on one VPS:** each gets its own user, its own
+  `WorkingDirectory`, and its own systemd unit. Caddy in front
+  handles host-based routing.
+- **No reverse proxy:** set `HOSTNAME=0.0.0.0` and
+  `Environment=PORT=80` in the unit, plus `AmbientCapabilities=CAP_NET_BIND_SERVICE`
+  to bind a privileged port as non-root.
+
+## Cost reference
+
+A single binary deployment runs comfortably on a $4–6/mo VPS for
+typical Next.js apps. Add caddy in front for free TLS. No platform
+fees, no per-invocation costs, no surprise bills.

--- a/examples/vps-deploy/app/api/healthz/route.ts
+++ b/examples/vps-deploy/app/api/healthz/route.ts
@@ -1,0 +1,10 @@
+/**
+ * Health check endpoint. The systemd unit in `systemd/next-app.service`
+ * doesn't poll this directly (systemd is process-up-or-down only), but
+ * it's used by the GitHub Actions deploy workflow's post-deploy smoke
+ * test, and by anything fronting the binary (caddy, nginx, a load
+ * balancer) that wants a deeper readiness signal than TCP-accept.
+ */
+export async function GET() {
+  return Response.json({ ok: true, ts: Date.now() });
+}

--- a/examples/vps-deploy/app/layout.tsx
+++ b/examples/vps-deploy/app/layout.tsx
@@ -1,0 +1,11 @@
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/examples/vps-deploy/app/page.tsx
+++ b/examples/vps-deploy/app/page.tsx
@@ -1,0 +1,11 @@
+export default function Home() {
+  return (
+    <main>
+      <h1>vps-deploy example</h1>
+      <p>
+        This page is being served by a single Bun binary on a VPS that has
+        no node, no bun, and no node_modules installed.
+      </p>
+    </main>
+  );
+}

--- a/examples/vps-deploy/next.config.ts
+++ b/examples/vps-deploy/next.config.ts
@@ -1,0 +1,7 @@
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {
+  adapterPath: import.meta.resolve("next-bun-compile"),
+};
+
+export default nextConfig;

--- a/examples/vps-deploy/package.json
+++ b/examples/vps-deploy/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "example-vps-deploy",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "next build && next-bun-compile",
+    "build:linux-x64": "next build && next-bun-compile --target=bun-linux-x64",
+    "build:linux-arm64": "next build && next-bun-compile --target=bun-linux-arm64"
+  },
+  "dependencies": {
+    "next": "16.2.7",
+    "react": "^19.2.0",
+    "react-dom": "^19.2.0"
+  },
+  "devDependencies": {
+    "next-bun-compile": "file:../..",
+    "@types/node": "^22",
+    "@types/react": "^19",
+    "@types/react-dom": "^19",
+    "typescript": "^5"
+  }
+}

--- a/examples/vps-deploy/systemd/next-app.service
+++ b/examples/vps-deploy/systemd/next-app.service
@@ -1,0 +1,62 @@
+# Systemd unit for a next-bun-compile binary.
+#
+# Install:
+#   sudo cp next-app.service /etc/systemd/system/
+#   sudo systemctl daemon-reload
+#   sudo systemctl enable next-app
+#   sudo systemctl start next-app
+#
+# Status / logs:
+#   sudo systemctl status next-app
+#   journalctl -u next-app -f
+#
+# Substitute the values marked TODO before installing.
+
+[Unit]
+Description=Next.js app (next-bun-compile binary)
+After=network.target
+
+[Service]
+Type=simple
+
+# TODO: non-root user that owns APP_DIR. Create with:
+#   sudo useradd -r -s /bin/false -d /srv/next-app deploy
+User=deploy
+Group=deploy
+
+# TODO: the directory the GitHub Actions workflow uploads `server` into.
+# Must match the APP_DIR repo variable. The binary `cwd`s here at boot
+# (via `process.chdir(baseDir)`) and writes its extracted assets in
+# `.next/` and `public/` relative to this dir.
+WorkingDirectory=/srv/next-app
+ExecStart=/srv/next-app/server
+
+# Restart on crash; back off if it crashes repeatedly so we don't
+# pin a CPU on a doomed configuration.
+Restart=on-failure
+RestartSec=5s
+StartLimitIntervalSec=60s
+StartLimitBurst=5
+
+# Bind to a non-privileged port. Put caddy/nginx in front for TLS +
+# port 80/443 → this port. CAP_NET_BIND_SERVICE would let the binary
+# bind 80/443 directly without root, but reverse proxies are usually
+# simpler.
+Environment=NODE_ENV=production
+Environment=PORT=3000
+Environment=HOSTNAME=127.0.0.1
+
+# Hardening — drop everything we don't need. Adjust if your app
+# legitimately needs more (e.g. WRITE_PATHS for an upload dir).
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=true
+ReadWritePaths=/srv/next-app
+
+# Logging goes to journalctl.
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/examples/vps-deploy/tsconfig.json
+++ b/examples/vps-deploy/tsconfig.json
@@ -1,0 +1,37 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    ".next"
+  ]
+}


### PR DESCRIPTION
## Summary

A new recipe + working example for the single-binary deploy story: build the Linux binary in GitHub Actions, scp it to a VPS over SSH, run under systemd. The VPS needs nothing installed but ssh, systemd, and glibc — no node, no bun, no node_modules, no Docker.

This is the killer use case for a single-binary compiler: literally no other Next.js deploy approach can offer "scp one file and you're done."

## What's in the diff

- **\`examples/vps-deploy/\`** — minimal Next.js app + the complete deploy pipeline:
  - \`.github/workflows/deploy.yml\` — checkout, build linux-x64, scp + atomic \`mv\` + \`systemctl restart\` + smoke test against \`/api/healthz\`
  - \`systemd/next-app.service\` — unit file with non-root user, crash restart, hardened sandbox
  - \`README.md\` — full one-time VPS setup (deploy user, SSH key, systemd install, optional caddy for TLS) and per-deploy flow
  - \`app/api/healthz/route.ts\` — readiness endpoint the workflow polls post-deploy

- **\`docs/.../recipes/vps-deploy.mdx\`** — same content as a docs page on the Starlight site, linked from the examples index.

## Test plan

- [x] Example builds + boots locally; \`/api/healthz\` returns 200
- [x] Docs site builds (14 pages now, was 13)
- [ ] Not added as an e2e CI job — would need a real VPS to exercise the SSH/systemd flow. The binary's build + boot path is already covered by the \`e2e-sharp\` and \`e2e-monorepo\` jobs; what's new here (the deploy workflow, the unit file) is reference material, not runtime code.

## Notes

- The example targets \`bun-linux-x64\` by default. The \`package.json\` includes a \`build:linux-arm64\` script for ARM VPS (Hetzner, Oracle, Graviton).
- Native deps (sharp etc.) work on any glibc-based VPS without extra setup. For sharp's text rendering, the README notes the one-line \`apt install fontconfig fonts-dejavu-core\`.